### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d431839ab4494499714f2b6f001413fe380607eb",
-        "sha256": "0liwhzy3rai0vxxa8985f1aw4y3ha39vgkfjslbsf5h79f3xf8im",
+        "rev": "7a08a9b2fba56b23d4a076727ffa0c1e74f083e5",
+        "sha256": "0frzh8imwamgqi7m6w5j4nyarkvrgm80ic22wbbzci4nnn9p8h8q",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d431839ab4494499714f2b6f001413fe380607eb.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/7a08a9b2fba56b23d4a076727ffa0c1e74f083e5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       | Timestamp              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d5327b6d`](https://github.com/NixOS/nixpkgs/commit/d5327b6de285eaff4d525daa8203467c990f61db) | `reddsaver: 0.3.3 -> 0.4.0`                                                                          | `2021-09-05 06:25:06Z` |
| [`96f5319a`](https://github.com/NixOS/nixpkgs/commit/96f5319abb2195c877453696c6a906c0b29df3d3) | `hck: 0.6.1 -> 0.6.2`                                                                                | `2021-09-05 01:09:53Z` |
| [`2837f7a6`](https://github.com/NixOS/nixpkgs/commit/2837f7a6944432c7e38365681859635dd81288dc) | `python3Packages.deprecated: remove unused tox dependency`                                           | `2021-09-04 23:22:30Z` |
| [`c879a416`](https://github.com/NixOS/nixpkgs/commit/c879a416bbcf94f2895bc80ec970f8dd2b4f3cf8) | `super-slicer: 2.3.56.5 -> 2.3.56.8`                                                                 | `2021-09-04 20:00:11Z` |
| [`4a4294d7`](https://github.com/NixOS/nixpkgs/commit/4a4294d74be2c6fdc2041275762a8a1dc7216a0b) | `vim-plugins.direnv.vim: fix directory for substitution`                                             | `2021-09-04 19:55:24Z` |
| [`287383c6`](https://github.com/NixOS/nixpkgs/commit/287383c61e51b1e11f933550e4a9acfe9d3477c5) | `emacs.pkgs.bqn-mode: init at unstable-2021-09-04`                                                   | `2021-09-04 17:57:51Z` |
| [`d7b70ffc`](https://github.com/NixOS/nixpkgs/commit/d7b70ffc4d636a7592efd2529f1e5d96f89eb9ea) | `vim-plugins: add wincent/terminus`                                                                  | `2021-09-04 17:57:40Z` |
| [`f7ebeacf`](https://github.com/NixOS/nixpkgs/commit/f7ebeacf4ab01477b94369685f3785fde983c2ac) | `vimPlugins: add vim-python/python-syntax`                                                           | `2021-09-04 17:57:39Z` |
| [`61f72ef0`](https://github.com/NixOS/nixpkgs/commit/61f72ef0294d347b6e62663d0dca77e2078b3114) | `vimPlugins: add RobertAudi/securemodelines`                                                         | `2021-09-04 17:57:39Z` |
| [`0efb0a67`](https://github.com/NixOS/nixpkgs/commit/0efb0a67f869650673477045e85dc5b3d6447ccd) | `vimPlugins: add neoclide/jsonc.vim`                                                                 | `2021-09-04 17:57:39Z` |
| [`de0b857f`](https://github.com/NixOS/nixpkgs/commit/de0b857f8a9f26e380ed67800db18693e2a0f50b) | `vimPlugins: add junegunn/vim-emoji`                                                                 | `2021-09-04 17:57:38Z` |
| [`eb5dcf81`](https://github.com/NixOS/nixpkgs/commit/eb5dcf8115bde2110620bbe77b161a6bddd49803) | `vimPlugins: add edkolev/tmuxline.vim`                                                               | `2021-09-04 17:57:38Z` |
| [`da375dee`](https://github.com/NixOS/nixpkgs/commit/da375deef35659edd5fcda57c56334cdd1e66746) | `vimPlugins: add chr4/sslsecure.vim`                                                                 | `2021-09-04 17:57:37Z` |
| [`d28c708b`](https://github.com/NixOS/nixpkgs/commit/d28c708bc75425eccff806ca975c2d309c00dd18) | `vimPlugins: rename tami5/sql.lua to tami5/sqlite.lua`                                               | `2021-09-04 17:57:37Z` |
| [`a7bf9ea8`](https://github.com/NixOS/nixpkgs/commit/a7bf9ea8b5e773d9b4f49a7c28d63f636f07e181) | `grafana: support darwin`                                                                            | `2021-09-04 17:27:07Z` |
| [`f04979d6`](https://github.com/NixOS/nixpkgs/commit/f04979d632fde0a200126a0de134550d9bcbb4bc) | `notejot: 3.1.1 -> 3.1.2`                                                                            | `2021-09-04 14:54:44Z` |
| [`5e6a41c4`](https://github.com/NixOS/nixpkgs/commit/5e6a41c43c5153313612197798c9a673ae4a32ab) | `weechat: 3.2 -> 3.2.1`                                                                              | `2021-09-04 14:54:32Z` |
| [`dd63f999`](https://github.com/NixOS/nixpkgs/commit/dd63f999bd90c678d8ccf1faf3b1ddb3abf3a157) | `treewide: remove dummy file`                                                                        | `2021-09-04 14:38:24Z` |
| [`4ebe496b`](https://github.com/NixOS/nixpkgs/commit/4ebe496bad646a9e99f79250f885d7144fe39230) | `trellis: 2021.07.06 -> 2021-09-01`                                                                  | `2021-09-04 14:19:53Z` |
| [`4fef4315`](https://github.com/NixOS/nixpkgs/commit/4fef4315e8ea3f56b69880298bab7bb7d212b3be) | `bundler-audit: 0.8.0 → 0.9.0.1`                                                                     | `2021-09-04 14:06:53Z` |
| [`e01a8047`](https://github.com/NixOS/nixpkgs/commit/e01a8047d532b65d77ef4fdac8620670f1ddd411) | `python3Packages.surepy: 0.7.0 -> 0.7.1`                                                             | `2021-09-04 13:14:17Z` |
| [`7c0b350d`](https://github.com/NixOS/nixpkgs/commit/7c0b350d943312fffa10090b5884a2bf5e9d3902) | `gitleaks: 7.5.0 -> 7.6.0`                                                                           | `2021-09-04 12:33:19Z` |
| [`d68ca993`](https://github.com/NixOS/nixpkgs/commit/d68ca99316080e6d17a1851752b30ebb22f87395) | `vscode-extensions.viktorqvarfordt.vscode-pitch-black-theme: init at 1.2.4`                          | `2021-09-04 12:28:56Z` |
| [`dc2ad494`](https://github.com/NixOS/nixpkgs/commit/dc2ad49441526afbbe5942878e9d1fa372f793ad) | `python3Packages.anyascii: 0.2.0 -> 0.3.0`                                                           | `2021-09-04 12:25:49Z` |
| [`90982af6`](https://github.com/NixOS/nixpkgs/commit/90982af6a14f75b148f98ac6cc09c569b14c0b61) | `rust-analyzer: 2021-08-23 -> 2021-08-30`                                                            | `2021-09-04 11:18:35Z` |
| [`5f84dad7`](https://github.com/NixOS/nixpkgs/commit/5f84dad75d24322ffe361a635e76839eee4aaa1f) | `kak-lsp: 10.0.0 -> 11.0.0`                                                                          | `2021-09-04 11:02:34Z` |
| [`e0f90f86`](https://github.com/NixOS/nixpkgs/commit/e0f90f86e9e73668efd7c71fe473db4c318d6798) | `procs: add changelog to meta`                                                                       | `2021-09-04 10:53:22Z` |
| [`9cf254c4`](https://github.com/NixOS/nixpkgs/commit/9cf254c40c6fbc559d8ff5007d74c7384b476610) | `procs: fix completions installation`                                                                | `2021-09-04 10:53:22Z` |
| [`40eae2c9`](https://github.com/NixOS/nixpkgs/commit/40eae2c9159a06bcbdcbd9482b7f66a87dafb6bf) | `python3Packages.aiolifx: 0.6.10 -> 0.7.0`                                                           | `2021-09-04 09:40:17Z` |
| [`a442e572`](https://github.com/NixOS/nixpkgs/commit/a442e572cbc1edf6a53e6684edfd43e1840c35e9) | `intel-media-driver: 21.3.2 -> 21.3.3`                                                               | `2021-09-04 09:32:10Z` |
| [`81ba8bbd`](https://github.com/NixOS/nixpkgs/commit/81ba8bbd675bc7bd296863a99185843b604e5335) | `python38Packages.mailmanclient: 3.3.2 -> 3.3.3`                                                     | `2021-09-04 09:24:35Z` |
| [`cb335144`](https://github.com/NixOS/nixpkgs/commit/cb335144651db48c36eeedf30c497e514482b11e) | `python38Packages.eth-hash: 0.3.1 -> 0.3.2`                                                          | `2021-09-04 08:28:47Z` |
| [`41f7f653`](https://github.com/NixOS/nixpkgs/commit/41f7f6539c912f3280e536bcc18c38d8cc8a46f3) | `python38Packages.ledgerblue: 0.1.35 -> 0.1.37`                                                      | `2021-09-04 08:28:39Z` |
| [`8cc6f5fd`](https://github.com/NixOS/nixpkgs/commit/8cc6f5fdd8565fec6f8280675b8565d121de6774) | `exploitdb: 2021-09-01 -> 2021-09-03`                                                                | `2021-09-04 06:56:20Z` |
| [`3c836e9a`](https://github.com/NixOS/nixpkgs/commit/3c836e9a822cdfbc7352f918c9bb8a5dbfe8eb5b) | `python3Packages.markdown-it-py: use pythonImportsCheck instead of pytestImportsCheck`               | `2021-09-04 00:47:21Z` |
| [`9232fbdc`](https://github.com/NixOS/nixpkgs/commit/9232fbdc5d6a66c95fd6a2623f06f73513da1ae4) | `vim-plugins: update`                                                                                | `2021-09-03 23:26:38Z` |
| [`fc5196c2`](https://github.com/NixOS/nixpkgs/commit/fc5196c2f089e1483429aecd8dff56387a444e6b) | `libredirect: add subprocess test`                                                                   | `2021-09-03 21:45:46Z` |
| [`bb13c55e`](https://github.com/NixOS/nixpkgs/commit/bb13c55e6c93214e309673fa36540f6b0f9d0e7a) | `vimPackages: rename nathunsmitty/nvim-ale-diagnostic@main to nathanmsmith/nvim-ale-diagnostic@main` | `2021-09-03 21:08:42Z` |
| [`08fee95d`](https://github.com/NixOS/nixpkgs/commit/08fee95dce40525555d902f740da05d2b53091e5) | `heisenbridge: 1.0.0 -> 1.0.1`                                                                       | `2021-09-03 20:50:53Z` |
| [`e3e971fc`](https://github.com/NixOS/nixpkgs/commit/e3e971fc75054c387e708d23e57d21fbbdc1bbbb) | `metabigor: init at 1.9`                                                                             | `2021-09-03 20:46:02Z` |
| [`4961547d`](https://github.com/NixOS/nixpkgs/commit/4961547d05376023fdc7a4664aba4d933d43e7b5) | `libredirect: Fix redirects not working for subprocesses`                                            | `2021-09-03 20:26:22Z` |
| [`0afbd6c8`](https://github.com/NixOS/nixpkgs/commit/0afbd6c86a29160386e5386332b65ba707a25340) | `libredirect: Enable debug symbols`                                                                  | `2021-09-03 20:26:21Z` |
| [`5ca02655`](https://github.com/NixOS/nixpkgs/commit/5ca02655057bb568f09b3aed4acee44e3f805291) | `libredirect: Add missing phase hooks`                                                               | `2021-09-03 20:26:20Z` |
| [`7cfd9fcd`](https://github.com/NixOS/nixpkgs/commit/7cfd9fcd8f61a6c01591988ccb8f884736cd4719) | `credential-detector: init at 1.7.0`                                                                 | `2021-09-03 20:01:11Z` |
| [`12571055`](https://github.com/NixOS/nixpkgs/commit/12571055cfb2fb32b096d786b9766a76e9f7e93f) | `gotestwaf: init at 0.3.1`                                                                           | `2021-09-03 19:18:14Z` |
| [`dbb78328`](https://github.com/NixOS/nixpkgs/commit/dbb78328cff22b32ca401d86d3fb3fe51ff4353c) | `dalfox: init at 2.4.9`                                                                              | `2021-09-03 19:02:38Z` |
| [`439c6eb7`](https://github.com/NixOS/nixpkgs/commit/439c6eb770c50277b977e70a8600868c9af705e1) | `scilla: 20210118 -> 1.1.1`                                                                          | `2021-09-03 18:29:43Z` |
| [`cfd5c585`](https://github.com/NixOS/nixpkgs/commit/cfd5c58596a5d38459f0c4245598c21fc63282dc) | `vimPlugins.crates-nvim: init at 2021-09-03`                                                         | `2021-09-03 17:19:00Z` |
| [`ca899bfe`](https://github.com/NixOS/nixpkgs/commit/ca899bfe66b54b6a982f8ddfb960786564e581e6) | `hck: 0.5.4 -> 0.6.1`                                                                                | `2021-09-03 15:55:19Z` |
| [`1ef95334`](https://github.com/NixOS/nixpkgs/commit/1ef95334b7b494f0e2c5e5991a4c12cd93677222) | `dockfmt: add version information`                                                                   | `2021-09-03 15:06:10Z` |
| [`fe182538`](https://github.com/NixOS/nixpkgs/commit/fe1825384743f35e7caddb1b596b6de499e22925) | `dockfmt: init at 0.3.3`                                                                             | `2021-09-03 15:06:09Z` |
| [`fbb49171`](https://github.com/NixOS/nixpkgs/commit/fbb4917115ce1e141a75ac257ea9234fc3b95aa2) | `domoticz: 2020.2 -> 2021.1`                                                                         | `2021-09-03 08:24:14Z` |
| [`ed19d70d`](https://github.com/NixOS/nixpkgs/commit/ed19d70dc65965449deba7d76a7ca22f2c448f60) | `papirus-icon-theme: 20210802 -> 20210901`                                                           | `2021-09-03 07:51:49Z` |
| [`b20e6dc8`](https://github.com/NixOS/nixpkgs/commit/b20e6dc83ce51632d4a09f0ab8a114c03f2d88eb) | `python3Packages.xdis: 5.0.10 -> 5.0.11`                                                             | `2021-09-03 07:35:02Z` |
| [`a9aae586`](https://github.com/NixOS/nixpkgs/commit/a9aae5868d837f09a71acd0b64f00d8ddb623843) | `python3Packages.fakeredis: 1.5.2 -> 1.6.0`                                                          | `2021-09-03 07:20:14Z` |
| [`6781cfad`](https://github.com/NixOS/nixpkgs/commit/6781cfad4ff0c4005a6a9b8d84c3d86b7b60f172) | `python3Packages.lupa: 1.9 -> 1.10`                                                                  | `2021-09-03 06:33:42Z` |
| [`df6aa843`](https://github.com/NixOS/nixpkgs/commit/df6aa8432ae29406fb7aae439258d20fb0188ef4) | `electron_14: init at 14.0.0`                                                                        | `2021-09-03 06:33:40Z` |
| [`e4c99a00`](https://github.com/NixOS/nixpkgs/commit/e4c99a0008367de4ca5ba0c46a5f5464f3e13bc5) | `python3Packages.dpath: 2.0.1 -> 2.0.2`                                                              | `2021-09-03 06:27:42Z` |
| [`5111ac57`](https://github.com/NixOS/nixpkgs/commit/5111ac576445177a7b0edf9a53960f95b0dfb130) | `jibri: init at 8.0-93-g51fe7a2`                                                                     | `2021-09-03 03:13:35Z` |
| [`4f568d65`](https://github.com/NixOS/nixpkgs/commit/4f568d652e9369fc2bd3a4c22ee48bd8a7bd97e0) | `electron_13: 13.2.3 -> 13.3.0`                                                                      | `2021-09-03 01:06:39Z` |
| [`26f46d56`](https://github.com/NixOS/nixpkgs/commit/26f46d56f8079ba77b75f0b1f9f39d05b27eed18) | `electron_12: 12.0.18 -> 12.1.0`                                                                     | `2021-09-03 01:06:14Z` |
| [`b989a80b`](https://github.com/NixOS/nixpkgs/commit/b989a80b900ba2941988a1800bf50628615339ab) | `electron_11: 11.4.12 -> 11.5.0`                                                                     | `2021-09-03 01:05:59Z` |
| [`90ad1ea7`](https://github.com/NixOS/nixpkgs/commit/90ad1ea7e76166f42111eee25969843b851d900a) | `chatty: 0.3.2 -> 0.3.4`                                                                             | `2021-09-03 00:10:42Z` |
| [`14d281d6`](https://github.com/NixOS/nixpkgs/commit/14d281d6901a9e150ad40cb324faea2dad25fb30) | `python3Packages.aiokafka: 0.7.1 -> 0.7.2`                                                           | `2021-09-02 21:52:37Z` |
| [`cd2ee8bc`](https://github.com/NixOS/nixpkgs/commit/cd2ee8bc2a68261d2dadb7a9e03ebb59a96a4923) | `hugo: 0.87.0 -> 0.88.0`                                                                             | `2021-09-02 21:41:49Z` |
| [`2d9bf013`](https://github.com/NixOS/nixpkgs/commit/2d9bf0131075011006fa0ed5e29c27d4f1db39d0) | `rofi: 1.6.1 -> 1.7.0`                                                                               | `2021-09-02 21:15:45Z` |
| [`d60f63ec`](https://github.com/NixOS/nixpkgs/commit/d60f63ec966a52108a8a22a9aa53d0c0f31eac5a) | `Python3Packages.versiontag: init at 1.2.0`                                                          | `2021-09-02 16:09:38Z` |
| [`de8c9e02`](https://github.com/NixOS/nixpkgs/commit/de8c9e02be99ce7ad2651c11cf43d0a7be8296d1) | `nginxModules: recurse into attrs`                                                                   | `2021-09-02 15:18:47Z` |
| [`e02b8099`](https://github.com/NixOS/nixpkgs/commit/e02b80996920d0bdf94813cd1da5cb258cb04513) | `maintainers: add staccato`                                                                          | `2021-09-02 09:33:16Z` |
| [`06dbc404`](https://github.com/NixOS/nixpkgs/commit/06dbc404f02dea00871e954c10ec2eac1cbea6a8) | `rstcheck: init at 3.3.1`                                                                            | `2021-09-02 09:33:07Z` |
| [`c7b320cc`](https://github.com/NixOS/nixpkgs/commit/c7b320cc3943b5c4fdd5408628bdbe6f8a3f1498) | `python38Packages.google-cloud-bigquery: 2.25.1 -> 2.26.0`                                           | `2021-09-02 08:53:02Z` |
| [`0721ce3f`](https://github.com/NixOS/nixpkgs/commit/0721ce3ff1caa7c3d8ed7e725450545e303aa98f) | `i3status-rust: install examples`                                                                    | `2021-09-01 14:35:33Z` |
| [`1e93f306`](https://github.com/NixOS/nixpkgs/commit/1e93f306ad3d865c36e5765b3a14197acb5562f0) | `python38Packages.google-resumable-media: 2.0.0 -> 2.0.1`                                            | `2021-09-01 13:22:48Z` |
| [`5c3289c3`](https://github.com/NixOS/nixpkgs/commit/5c3289c3580a01f00a28ec18d0b093a1c7aa4656) | `python38Packages.google-cloud-translate: 3.3.2 -> 3.4.0`                                            | `2021-08-31 21:35:39Z` |
| [`d84b3e68`](https://github.com/NixOS/nixpkgs/commit/d84b3e685deeede364adb1ee5f1c0d1398c48e5f) | `python38Packages.google-cloud-monitoring: 2.4.2 -> 2.5.0`                                           | `2021-08-31 21:28:10Z` |
| [`5acfdf2c`](https://github.com/NixOS/nixpkgs/commit/5acfdf2ce072838c475c9929462b75c0bb205073) | `python38Packages.google-cloud-firestore: 2.3.0 -> 2.3.1`                                            | `2021-08-31 21:23:14Z` |
| [`b00e4cb9`](https://github.com/NixOS/nixpkgs/commit/b00e4cb942648fef36a30617e9fc4197652e10d0) | `python38Packages.google-cloud-kms: 2.5.0 -> 2.6.0`                                                  | `2021-08-31 19:36:37Z` |
| [`f4333041`](https://github.com/NixOS/nixpkgs/commit/f4333041545ed41ba350f40b6cf5588e7982f7c5) | `python38Packages.google-cloud-os-config: 1.3.2 -> 1.4.0`                                            | `2021-08-31 19:31:44Z` |
| [`f42ac9bd`](https://github.com/NixOS/nixpkgs/commit/f42ac9bd1f3bc223507c34b28d55eb41cd5315f4) | `python38Packages.google-cloud-spanner: 3.8.0 -> 3.9.0`                                              | `2021-08-31 18:04:02Z` |
| [`38d0c7c3`](https://github.com/NixOS/nixpkgs/commit/38d0c7c35a407cff1ce95621ed68ac72090dc18f) | `python38Packages.google-cloud-speech: 2.7.0 -> 2.8.0`                                               | `2021-08-31 17:59:06Z` |
| [`7a750b53`](https://github.com/NixOS/nixpkgs/commit/7a750b53e53804b971d9b197473b2dc460e28a47) | `pipes-rs: init at 1.4.4`                                                                            | `2021-08-31 09:17:56Z` |
| [`e1ce3ce0`](https://github.com/NixOS/nixpkgs/commit/e1ce3ce0c457ef2e46e66947f657705793c51707) | `tfk8s: 0.1.6 -> 0.1.7`                                                                              | `2021-08-30 21:21:26Z` |
| [`4f7012be`](https://github.com/NixOS/nixpkgs/commit/4f7012bef7c767b46027ef885e6e3c0ad914189d) | `sonic-pi: wrap sonic-pi-server.rb as standalone executable`                                         | `2021-08-27 17:01:51Z` |
| [`c460e15a`](https://github.com/NixOS/nixpkgs/commit/c460e15a46bb3c0655400e7a309542b0c2f31df1) | `fluxcd: 0.16.2 -> 0.17.0`                                                                           | `2021-08-27 15:25:07Z` |
| [`4162b4c2`](https://github.com/NixOS/nixpkgs/commit/4162b4c284426b13d483109d95c2d3d59dd1ec25) | `maintainers: add MaskedBelgian`                                                                     | `2021-08-26 08:54:07Z` |