### PR TITLE
refactor: reduce row reification

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -23,6 +23,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "atpublic"
+version = "2.3"
+description = "public -- @public for populating __all__"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing_extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "attrs"
 version = "21.2.0"
 description = "Classes Without Boilerplate"
@@ -640,7 +651,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -675,7 +686,7 @@ animation = ["pydot"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "18c953a7c6ca9e575ce20a065fe1c18077e87591fb26f4fec5b2c935e87ecf6b"
+content-hash = "01168a8a9c959d11ceb8c98286224f25d27e04cd259fa38e78b4bb3a3246d926"
 
 [metadata.files]
 alabaster = [
@@ -689,6 +700,9 @@ appdirs = [
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+atpublic = [
+    {file = "atpublic-2.3.tar.gz", hash = "sha256:d6b9167fc3e09a2de2d2adcfc9a1b48d84eab70753c97de3800362e1703e3367"},
 ]
 attrs = [
     {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -686,7 +686,7 @@ animation = ["pydot"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "01168a8a9c959d11ceb8c98286224f25d27e04cd259fa38e78b4bb3a3246d926"
+content-hash = "5688092cf1ef8b08134cbda8b35dd1d677cfc806ca5fda195ece9a58975a53d4"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+atpublic = "^2.3"
 cytoolz = "^0.11"
 pydot = { version = "^1", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-atpublic = "^2.3"
+atpublic = "^2"
 cytoolz = "^0.11"
 pydot = { version = "^1", optional = true }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alabaster==0.7.12; python_version >= "3.6"
 appdirs==1.4.4; python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+atpublic==2.3; python_version >= "3.6"
 attrs==21.2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 babel==2.9.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 black==20.8b1; python_version >= "3.6"
@@ -52,6 +53,6 @@ sphinxcontrib-serializinghtml==1.1.5; python_version >= "3.6"
 toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 toolz==0.11.1; python_version >= "3.5"
 typed-ast==1.4.3; python_version >= "3.6"
-typing-extensions==3.10.0.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6"
+typing-extensions==3.10.0.2; python_version < "3.8" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6")
 urllib3==1.26.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 zipp==3.5.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.6"

--- a/stupidb/api.py
+++ b/stupidb/api.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Iterable, Mapping, Optional
 
+from public import private, public
 from toolz import curry
 
 from .aggregation import Window  # noqa: F401
@@ -74,7 +75,8 @@ from .row import AbstractRow
 from .typehints import R1, R2, OrderBy, R, T
 
 
-class _shiftable(curry):
+@private  # type: ignore[misc]
+class shiftable(curry):
     """Shiftable curry."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -85,11 +87,12 @@ class _shiftable(curry):
     def __signature__(self) -> inspect.Signature:
         return inspect.signature(self.func)  # pragma: no cover
 
-    def __rrshift__(self, other: Relation) -> _shiftable:
+    def __rrshift__(self, other: Relation) -> shiftable:
         return self(other)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def table(rows: Iterable[Mapping[str, Any]]) -> Table:
     """Construct a relation from an iterable of mappings.
 
@@ -100,7 +103,7 @@ def table(rows: Iterable[Mapping[str, Any]]) -> Table:
 
     Examples
     --------
-    >>> from stupidb.api import table
+    >>> from stupidb import table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Bob", balance=-100),
@@ -115,7 +118,8 @@ def table(rows: Iterable[Mapping[str, Any]]) -> Table:
     return Table.from_iterable(rows)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def cross_join(right: Relation, left: Relation) -> Join:
     """Return the Cartesian product of tuples from `left` and `right`.
 
@@ -128,7 +132,7 @@ def cross_join(right: Relation, left: Relation) -> Join:
 
     Examples
     --------
-    >>> from stupidb.api import cross_join, table
+    >>> from stupidb import cross_join, table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Bob", balance=-100),
@@ -145,7 +149,8 @@ def cross_join(right: Relation, left: Relation) -> Join:
     return CrossJoin(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def inner_join(right: Relation, predicate: JoinPredicate, left: Relation) -> Join:
     """Join `left` and `right` relations using `predicate`.
 
@@ -160,7 +165,7 @@ def inner_join(right: Relation, predicate: JoinPredicate, left: Relation) -> Joi
 
     Examples
     --------
-    >>> from stupidb.api import cross_join, table
+    >>> from stupidb import cross_join, table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Bob", balance=-100),
@@ -177,7 +182,8 @@ def inner_join(right: Relation, predicate: JoinPredicate, left: Relation) -> Joi
     return InnerJoin(left, right, predicate)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def left_join(right: Relation, predicate: JoinPredicate, left: Relation) -> LeftJoin:
     """Join `left` and `right` relations using `predicate`.
 
@@ -195,7 +201,8 @@ def left_join(right: Relation, predicate: JoinPredicate, left: Relation) -> Left
     return LeftJoin(left, right, predicate)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def right_join(right: Relation, predicate: JoinPredicate, left: Relation) -> RightJoin:
     """Join `left` and `right` relations using `predicate`.
 
@@ -213,11 +220,13 @@ def right_join(right: Relation, predicate: JoinPredicate, left: Relation) -> Rig
     return RightJoin(left, right, predicate)
 
 
-@_shiftable
+@private  # type: ignore[misc]
+@shiftable
 def _order_by(order_by: Tuple[OrderBy, ...], nulls: Nulls, child: Relation) -> SortBy:
     return SortBy(child, order_by, nulls)
 
 
+@public  # type: ignore[misc]
 def order_by(*order_by: OrderBy, nulls: Nulls = Nulls.FIRST) -> SortBy:
     """Order the rows of the child operator according to `order_by`.
 
@@ -234,7 +243,7 @@ def order_by(*order_by: OrderBy, nulls: Nulls = Nulls.FIRST) -> SortBy:
 
     Examples
     --------
-    >>> from stupidb.api import order_by, table
+    >>> from stupidb import order_by, table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Alice", balance=400),
@@ -250,11 +259,13 @@ def order_by(*order_by: OrderBy, nulls: Nulls = Nulls.FIRST) -> SortBy:
     return _order_by(order_by, nulls)
 
 
-@_shiftable
+@private  # type: ignore[misc]
+@shiftable
 def _select(projectors: Mapping[str, FullProjector], child: Relation) -> Projection:
     return Projection(child, projectors)
 
 
+@public  # type: ignore[misc]
 def select(**projectors: FullProjector) -> Projection:
     """Subset or compute new columns from `projectors`.
 
@@ -265,7 +276,7 @@ def select(**projectors: FullProjector) -> Projection:
 
     Examples
     --------
-    >>> from stupidb.api import select, table
+    >>> from stupidb import select, table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Alice", balance=400),
@@ -292,11 +303,13 @@ def select(**projectors: FullProjector) -> Projection:
     return _select(projectors)
 
 
-@_shiftable
+@private  # type: ignore[misc]
+@shiftable
 def _mutate(mutators: Mapping[str, FullProjector], child: Relation) -> Mutate:
     return Mutate(child, mutators)
 
 
+@public  # type: ignore[misc]
 def mutate(**mutators: FullProjector) -> Mutate:
     """Add new columns specified by `mutators`.
 
@@ -312,7 +325,7 @@ def mutate(**mutators: FullProjector) -> Mutate:
     Examples
     --------
     >>> from pprint import pprint
-    >>> from stupidb.api import mutate, table
+    >>> from stupidb import mutate, table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Alice", balance=400),
@@ -334,7 +347,8 @@ def mutate(**mutators: FullProjector) -> Mutate:
     return _mutate(mutators)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def sift(predicate: Predicate, child: Relation) -> Selection:
     """Filter rows in `child` according to `predicate`.
 
@@ -347,7 +361,7 @@ def sift(predicate: Predicate, child: Relation) -> Selection:
     Examples
     --------
     >>> from pprint import pprint
-    >>> from stupidb.api import sift, table
+    >>> from stupidb import sift, table
     >>> rows = [
     ...     dict(name="Bob", balance=-300),
     ...     dict(name="Alice", balance=400),
@@ -363,6 +377,7 @@ def sift(predicate: Predicate, child: Relation) -> Selection:
     return Selection(child, predicate)
 
 
+@public  # type: ignore[misc]
 def exists(relation: Relation) -> bool:
     """Compute whether any of the rows in `relation` are truthy.
 
@@ -372,13 +387,15 @@ def exists(relation: Relation) -> bool:
     return any(relation)
 
 
-@_shiftable
+@private  # type: ignore[misc]
+@shiftable
 def _aggregate(
     aggregations: Mapping[str, AggregateSpecification], child: Relation
 ) -> Aggregation:
     return Aggregation(child, aggregations)
 
 
+@public  # type: ignore[misc]
 def aggregate(**aggregations: AggregateSpecification) -> Aggregation:
     """Aggregate values from the child operator using `aggregations`.
 
@@ -393,7 +410,7 @@ def aggregate(**aggregations: AggregateSpecification) -> Aggregation:
     Compute the average of a column:
 
     >>> from pprint import pprint
-    >>> from stupidb.api import aggregate, group_by, mean, table
+    >>> from stupidb import aggregate, group_by, mean, table
     >>> rows = [
     ...     dict(name="Bob", age=30, timezone="America/New_York"),
     ...     dict(name="Susan", age=20, timezone="America/New_York"),
@@ -422,7 +439,8 @@ def aggregate(**aggregations: AggregateSpecification) -> Aggregation:
     return _aggregate(aggregations)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def over(
     window: FrameClause, child: AggregateSpecification
 ) -> WindowAggregateSpecification:
@@ -445,7 +463,7 @@ def over(
 
     Examples
     --------
-    >>> from stupidb.api import Window, over, mean, select, table
+    >>> from stupidb import Window, over, mean, select, table
     >>> from datetime import date, timedelta
     >>> today = date(2019, 2, 9)
     >>> days = timedelta(days=1)
@@ -479,11 +497,13 @@ def over(
     return WindowAggregateSpecification(child.aggregate_type, child.getters, window)
 
 
-@_shiftable
+@private  # type: ignore[misc]
+@shiftable
 def _group_by(group_by: Mapping[str, PartitionBy], child: Relation) -> GroupBy:
     return GroupBy(child, group_by)
 
 
+@public  # type: ignore[misc]
 def group_by(**group_by: PartitionBy) -> GroupBy:
     """Group the rows of the child operator according to `group_by`.
 
@@ -503,7 +523,7 @@ def group_by(**group_by: PartitionBy) -> GroupBy:
     Examples
     --------
     >>> from pprint import pprint
-    >>> from stupidb.api import aggregate, group_by, mean, table
+    >>> from stupidb import aggregate, group_by, mean, table
     >>> rows = [
     ...     dict(name="Bob", age=30, timezone="America/New_York"),
     ...     dict(name="Susan", age=20, timezone="America/New_York"),
@@ -526,8 +546,8 @@ def group_by(**group_by: PartitionBy) -> GroupBy:
     return _group_by(group_by)
 
 
-# Set operations
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def union(right: Relation, left: Relation) -> Union:
     """Compute the union of `left` and `right`, ignoring duplicate rows.
 
@@ -546,7 +566,8 @@ def union(right: Relation, left: Relation) -> Union:
     return Union(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def union_all(right: Relation, left: Relation) -> UnionAll:
     """Compute the union of `left` and `right`, preserving duplicate rows.
 
@@ -565,7 +586,8 @@ def union_all(right: Relation, left: Relation) -> UnionAll:
     return UnionAll(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def intersect(right: Relation, left: Relation) -> Intersect:
     """Compute the intersection of `left` and `right`, ignoring duplicate rows.
 
@@ -584,7 +606,8 @@ def intersect(right: Relation, left: Relation) -> Intersect:
     return Intersect(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def intersect_all(right: Relation, left: Relation) -> IntersectAll:
     """Compute the intersection of `left` and `right`, preserving duplicates.
 
@@ -603,7 +626,8 @@ def intersect_all(right: Relation, left: Relation) -> IntersectAll:
     return IntersectAll(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def difference(right: Relation, left: Relation) -> Difference:
     """Compute the set difference of `left` and `right`.
 
@@ -618,7 +642,8 @@ def difference(right: Relation, left: Relation) -> Difference:
     return Difference(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def difference_all(right: Relation, left: Relation) -> DifferenceAll:
     """Compute the set difference of `left` and `right`, preserving duplicates.
 
@@ -633,7 +658,8 @@ def difference_all(right: Relation, left: Relation) -> DifferenceAll:
     return DifferenceAll(left, right)
 
 
-@_shiftable
+@public  # type: ignore[misc]
+@shiftable
 def limit(limit: int, relation: Relation, *, offset: int = 0) -> Limit:
     """Return the rows in `relation` starting from `offset` up to `limit`.
 
@@ -654,7 +680,7 @@ def limit(limit: int, relation: Relation, *, offset: int = 0) -> Limit:
     return Limit(relation, offset=offset, limit=limit)
 
 
-# Aggregate functions
+@public  # type: ignore[misc]
 def count(x: Callable[[AbstractRow], Optional[T]]) -> AggregateSpecification:
     """Count the number of non-NULL values of `x`.
 
@@ -667,6 +693,7 @@ def count(x: Callable[[AbstractRow], Optional[T]]) -> AggregateSpecification:
     return AggregateSpecification(Count, (x,))
 
 
+@public  # type: ignore[misc]
 def sum(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the sum of `x`, with an empty column summing to NULL.
 
@@ -679,6 +706,7 @@ def sum(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     return AggregateSpecification(Sum, (x,))
 
 
+@public  # type: ignore[misc]
 def total(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the sum of `x`, with an empty column summing to zero.
 
@@ -691,6 +719,7 @@ def total(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     return AggregateSpecification(Total, (x,))
 
 
+@public  # type: ignore[misc]
 def first(x: Callable[[AbstractRow], Optional[T]]) -> AggregateSpecification:
     """Compute the first row of `x` over a window.
 
@@ -703,6 +732,7 @@ def first(x: Callable[[AbstractRow], Optional[T]]) -> AggregateSpecification:
     return AggregateSpecification(First, (x,))
 
 
+@public  # type: ignore[misc]
 def last(x: Callable[[AbstractRow], Optional[T]]) -> AggregateSpecification:
     """Compute the last row of `x` over a window.
 
@@ -715,11 +745,12 @@ def last(x: Callable[[AbstractRow], Optional[T]]) -> AggregateSpecification:
     return AggregateSpecification(Last, (x,))
 
 
+@public  # type: ignore[misc]
 def nth(
     x: Callable[[AbstractRow], Optional[T]],
     i: Callable[[AbstractRow], Optional[int]],
 ) -> AggregateSpecification:
-    """Compute the `i`th row of `x` over a window.
+    """Compute the `i`-th row of `x` over a window.
 
     Parameters
     ----------
@@ -732,21 +763,25 @@ def nth(
     return AggregateSpecification(Nth, (x, i))
 
 
+@public  # type: ignore[misc]
 def row_number() -> AggregateSpecification:
     """Compute the row number over a window."""
     return AggregateSpecification(RowNumber, ())
 
 
+@public  # type: ignore[misc]
 def rank() -> AggregateSpecification:
-    """Rank the rows of a relation based on the ordering key given in over."""
+    """Rank the rows of a relation based on the ordering key given in `over`."""
     return AggregateSpecification(Rank, ())
 
 
+@public  # type: ignore[misc]
 def dense_rank() -> AggregateSpecification:
-    """Rank the rows of a relation based on the ordering key given in over."""
+    """Rank the rows of a relation based on the ordering key given in `over`."""
     return AggregateSpecification(DenseRank, ())
 
 
+@public  # type: ignore[misc]
 def lead(
     x: Callable[[AbstractRow], Optional[T]],
     n: Callable[[AbstractRow], Optional[int]] = (lambda row: 1),
@@ -771,6 +806,7 @@ def lead(
     return AggregateSpecification(Lead, (x, n, default))
 
 
+@public  # type: ignore[misc]
 def lag(
     x: Callable[[AbstractRow], Optional[T]],
     n: Callable[[AbstractRow], Optional[int]] = (lambda row: 1),
@@ -795,6 +831,7 @@ def lag(
     return AggregateSpecification(Lag, (x, n, default))
 
 
+@public  # type: ignore[misc]
 def mean(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the average of a column.
 
@@ -807,6 +844,7 @@ def mean(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     return AggregateSpecification(Mean, (x,))
 
 
+@public  # type: ignore[misc]
 def min(x: Callable[[AbstractRow], Optional[Comparable]]) -> AggregateSpecification:
     """Compute the minimum of a column.
 
@@ -819,6 +857,7 @@ def min(x: Callable[[AbstractRow], Optional[Comparable]]) -> AggregateSpecificat
     return AggregateSpecification(Min, (x,))
 
 
+@public  # type: ignore[misc]
 def max(x: Callable[[AbstractRow], Optional[Comparable]]) -> AggregateSpecification:
     """Compute the maximum of a column.
 
@@ -831,6 +870,7 @@ def max(x: Callable[[AbstractRow], Optional[Comparable]]) -> AggregateSpecificat
     return AggregateSpecification(Max, (x,))
 
 
+@public  # type: ignore[misc]
 def cov_samp(
     x: Callable[[AbstractRow], R1], y: Callable[[AbstractRow], R2]
 ) -> AggregateSpecification:
@@ -847,6 +887,7 @@ def cov_samp(
     return AggregateSpecification(SampleCovariance, (x, y))
 
 
+@public  # type: ignore[misc]
 def var_samp(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the sample variance of a column.
 
@@ -859,6 +900,7 @@ def var_samp(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     return AggregateSpecification(SampleVariance, (x,))
 
 
+@public  # type: ignore[misc]
 def stdev_samp(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the sample standard deviation of a column.
 
@@ -871,6 +913,7 @@ def stdev_samp(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     return AggregateSpecification(SampleStandardDeviation, (x,))
 
 
+@public  # type: ignore[misc]
 def cov_pop(
     x: Callable[[AbstractRow], R1], y: Callable[[AbstractRow], R2]
 ) -> AggregateSpecification:
@@ -887,6 +930,7 @@ def cov_pop(
     return AggregateSpecification(PopulationCovariance, (x, y))
 
 
+@public  # type: ignore[misc]
 def var_pop(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the population variance of a column.
 
@@ -899,6 +943,7 @@ def var_pop(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     return AggregateSpecification(PopulationVariance, (x,))
 
 
+@public  # type: ignore[misc]
 def stdev_pop(x: Callable[[AbstractRow], R]) -> AggregateSpecification:
     """Compute the population standard deviation of a column.
 

--- a/stupidb/api.py
+++ b/stupidb/api.py
@@ -62,6 +62,7 @@ from .core import (
     RightJoin,
     Selection,
     SortBy,
+    Table,
     Tuple,
     Union,
     UnionAll,
@@ -89,7 +90,7 @@ class _shiftable(curry):
 
 
 @_shiftable
-def table(rows: Iterable[Mapping[str, Any]]) -> Relation:
+def table(rows: Iterable[Mapping[str, Any]]) -> Table:
     """Construct a relation from an iterable of mappings.
 
     Parameters
@@ -111,7 +112,7 @@ def table(rows: Iterable[Mapping[str, Any]]) -> Relation:
     <stupidb.core.Relation object at 0x...>
 
     """
-    return Relation.from_iterable(rows)
+    return Table.from_iterable(rows)
 
 
 @_shiftable

--- a/stupidb/core.py
+++ b/stupidb/core.py
@@ -19,7 +19,7 @@ import collections
 import functools
 import itertools
 import typing
-from typing import Any, FrozenSet, Generic, Iterable, Iterator, Mapping, NoReturn, Tuple
+from typing import Any, FrozenSet, Generic, Iterable, Iterator, Mapping, Tuple
 from typing import Union as Union_
 
 import cytoolz as toolz
@@ -52,8 +52,25 @@ class Relation(abc.ABC):
         self.partitioners: Mapping[str, PartitionBy] = {}
 
     def __iter__(self) -> Iterator[AbstractRow]:
-        """Iterate over the rows of a :class:`~stupidb.stupidb.Relation`."""
-        return (row._renew_id(id) for id, row in enumerate(filter(None, self.child)))
+        """Iterate over the rows of a :class:`~stupidb.stupidb.Relation`.
+
+        This method will reify rows with a new row identifier equal to the row number.
+
+        """
+        return (
+            Row.from_mapping(row, _id=id)
+            for id, row in enumerate(filter(None, self._produce()))
+        )
+
+    @abc.abstractmethod
+    def _produce(self) -> Iterator[AbstractRow]:
+        """Iterate over the rows of a :class:`~stupidb.stupidb.Relation`.
+
+        Specific relation should implement this without reifying the row with
+        the row identifier if possible. Reification is handled in the
+        :meth:`~stupidb.stupidb.Relation.__iter__` method.
+
+        """
 
 
 class Table(Relation):
@@ -63,6 +80,9 @@ class Table(Relation):
     def from_iterable(cls, iterable: Iterable[Mapping[str, Any]]) -> Relation:
         """Construct a :class:`~stupidb.stupidb.Table` from an iterable."""
         return cls(map(Row.from_mapping, iterable))
+
+    def _produce(self) -> Iterator[AbstractRow]:
+        return iter(self.child)
 
 
 FullProjector = Union_[Projector, WindowAggregateSpecification]
@@ -95,7 +115,7 @@ class Projection(Relation):
             if callable(projector)
         }
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         aggregations = self.aggregations
         # we need a row iterator for every aggregation to be fully generic
         # since they potentially share no structure
@@ -130,9 +150,9 @@ class Projection(Relation):
         # Use zip_longest here, because either of aggrows or projrows can be
         # empty
         return (
-            Row(toolz.merge(projrow, aggrow), _id=i)
-            for i, (aggrow, projrow) in enumerate(
-                itertools.zip_longest(aggrows, projrows, fillvalue={})
+            Row(toolz.merge(projrow, aggrow), _id=-1)
+            for aggrow, projrow in itertools.zip_longest(
+                aggrows, projrows, fillvalue={}
             )
         )
 
@@ -142,41 +162,35 @@ class Mutate(Projection):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         # reasign self.child here to avoid clobbering its iteration
         # we need to use it twice: once for the computed columns (self.child)
         # used during the iteration of super().__iter__() and once for the
         # original relation (child)
         child, self.child = itertools.tee(self.child)
         return (
-            Row.from_mapping(row, _id=i)
-            for i, row in enumerate(map(toolz.merge, child, super().__iter__()))
+            Row.from_mapping(row, _id=-1)
+            for row in map(toolz.merge, child, super()._produce())
         )
 
 
 class Aggregation(Generic[AssociativeAggregate], Relation):
-    """A relation representing aggregation of columns.
+    """A relation representing aggregation of columns."""
 
-    Attributes
-    ----------
-    aggregations
-
-    """
-
-    __slots__ = ("aggregations",)
+    __slots__ = ("metrics",)
 
     def __init__(
         self,
         child: Relation,
-        aggregations: Mapping[str, AggregateSpecification[AssociativeAggregate]],
+        metrics: Mapping[str, AggregateSpecification[AssociativeAggregate]],
     ) -> None:
         super().__init__(child)
-        self.aggregations: Mapping[
+        self.metrics: Mapping[
             str, AggregateSpecification[AssociativeAggregate]
-        ] = aggregations
+        ] = metrics
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        aggregations = self.aggregations
+    def _produce(self) -> Iterator[AbstractRow]:
+        aggregations = self.metrics
 
         # initialize aggregates
         grouped_aggs: Mapping[
@@ -196,14 +210,14 @@ class Aggregation(Generic[AssociativeAggregate], Relation):
                 inputs = (getter(row) for getter in aggregations[name].getters)
                 agg.step(*inputs)
 
-        for id, (grouping_key, aggs) in enumerate(grouped_aggs.items()):
+        for grouping_key, aggs in grouped_aggs.items():
             data = dict(grouping_key)
             data.update((name, agg.finalize()) for name, agg in aggs.items())
-            yield Row(data, _id=id)
+            yield Row.from_mapping(data)
 
 
 class Selection(Relation):
-    """A relation representing filtering rows based on a predicate.
+    """A relation of rows selected based on a predicate.
 
     Attributes
     ----------
@@ -219,11 +233,8 @@ class Selection(Relation):
         super().__init__(child)
         self.predicate = predicate
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        return (
-            row._renew_id(id)
-            for id, row in enumerate(filter(self.predicate, self.child))
-        )
+    def _produce(self) -> Iterator[AbstractRow]:
+        return filter(self.predicate, self.child)
 
 
 class GroupBy(Relation):
@@ -243,6 +254,9 @@ class GroupBy(Relation):
         super().__init__(child)
         self.partitioners = group_by
 
+    def _produce(self) -> Iterator[AbstractRow]:
+        return iter(self.child)
+
 
 class SortBy(Relation):
     """A relation representing rows of its child sorted by one or more keys.
@@ -252,30 +266,29 @@ class SortBy(Relation):
     order_by
         A callable that takes an :class:`~stupidb.row.AbstractRow` and returns
         an instance of :class:`~stupidb.protocols.Comparable`.
-    nulls
+    null_ordering
         Whether to place the nulls of a column first or last.
 
     """
 
-    __slots__ = "order_by", "nulls"
+    __slots__ = "order_by", "null_ordering"
 
     def __init__(
-        self, child: Relation, order_by: Tuple[OrderBy, ...], nulls: Nulls
+        self, child: Relation, order_by: Tuple[OrderBy, ...], null_ordering: Nulls
     ) -> None:
         super().__init__(child)
         self.order_by = order_by
-        self.nulls = nulls
+        self.null_ordering = null_ordering
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        return (
-            row._renew_id(id)
-            for id, row in enumerate(
-                sorted(
-                    self.child,
-                    key=functools.cmp_to_key(
-                        functools.partial(row_key_compare, self.order_by, self.nulls)
-                    ),
-                )
+    def _produce(self) -> Iterator[AbstractRow]:
+        return iter(
+            sorted(
+                self.child,
+                key=functools.cmp_to_key(
+                    functools.partial(
+                        row_key_compare, self.order_by, self.null_ordering
+                    )
+                ),
             )
         )
 
@@ -288,7 +301,7 @@ class Limit(Relation):
         self.offset = offset
         self.limit = limit
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         return itertools.islice(self.child, self.offset, self.offset + self.limit, None)
 
 
@@ -298,22 +311,21 @@ class Join(Relation):
     def __init__(self, left: Relation, right: Relation) -> None:
         self.grouped = itertools.groupby(
             (
-                JoinedRow(left_row, right_row, _id=i)
-                for i, (left_row, right_row) in enumerate(
-                    itertools.product(left, right)
-                )
+                JoinedRow(left_row, right_row, _id=-1)
+                for left_row, right_row in itertools.product(left, right)
             ),
             key=lambda row: row.left,
         )
-        super().__init__(row for _, rows in self.grouped for row in rows)
-
-    @classmethod
-    def from_iterable(cls, *args: Any, **kwargs: Any) -> NoReturn:
-        raise TypeError(f"from_iterable not supported for {cls.__name__} type")
+        super().__init__(
+            itertools.chain.from_iterable(rows for _, rows in self.grouped)
+        )
 
 
 class CrossJoin(Join):
     __slots__ = ()
+
+    def _produce(self) -> Iterator[AbstractRow]:
+        return iter(self.child)
 
 
 class InnerJoin(Join):
@@ -325,12 +337,8 @@ class InnerJoin(Join):
         super().__init__(left, right)
         self.predicate = predicate
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        return (
-            row._renew_id(id)
-            for id, row in enumerate(self.child)
-            if self.predicate(row.left, row.right)
-        )
+    def _produce(self) -> Iterator[AbstractRow]:
+        return (row for row in self.child if self.predicate(row.left, row.right))
 
 
 class LeftJoin(Join):
@@ -342,8 +350,7 @@ class LeftJoin(Join):
         super().__init__(left, right)
         self.predicate = predicate
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        k = 0
+    def _produce(self) -> Iterator[AbstractRow]:
         for left_row, joined_rows in self.grouped:
             matched = False
 
@@ -351,11 +358,9 @@ class LeftJoin(Join):
                 right_row = joined_row.right
                 if self.predicate(left_row, right_row):
                     matched = True
-                    yield JoinedRow(left_row, right_row, _id=k)
-                    k += 1
+                    yield JoinedRow(left_row, right_row, _id=-1)
             if not matched:
-                yield JoinedRow(left_row, dict.fromkeys(left_row), _id=k)
-                k += 1
+                yield JoinedRow(left_row, dict.fromkeys(left_row), _id=-1)
 
 
 class RightJoin(LeftJoin):
@@ -366,9 +371,9 @@ class RightJoin(LeftJoin):
     ) -> None:
         super().__init__(right, left, predicate)
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        for id, joined_row in enumerate(super().__iter__()):
-            yield JoinedRow(joined_row.right, joined_row.left, _id=id)
+    def _produce(self) -> Iterator[AbstractRow]:
+        for row in super()._produce():
+            yield JoinedRow(row.right, row.left)
 
 
 class SetOperation(Relation):
@@ -393,15 +398,10 @@ class Union(SetOperation):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        return (
-            Row.from_mapping(row, _id=id)
-            for id, row in enumerate(
-                toolz.unique(
-                    itertools.chain(self.left, self.right),
-                    key=lambda row: frozenset(row.items()),
-                )
-            )
+    def _produce(self) -> Iterator[AbstractRow]:
+        return toolz.unique(
+            itertools.chain(self.left, self.right),
+            key=lambda row: frozenset(row.items()),
         )
 
 
@@ -410,11 +410,8 @@ class UnionAll(SetOperation):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
-        return (
-            Row.from_mapping(row, _id=id)
-            for id, row in enumerate(itertools.chain(self.left, self.right))
-        )
+    def _produce(self) -> Iterator[AbstractRow]:
+        return itertools.chain(self.left, self.right)
 
 
 class IntersectAll(SetOperation):
@@ -422,18 +419,14 @@ class IntersectAll(SetOperation):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         left_set = self.itemize(self.left)
         right_set = self.itemize(self.right)
-        left_filtered = (
-            dict(row_items) for row_items in left_set if row_items in right_set
-        )
-        right_filtered = (
-            dict(row_items) for row_items in right_set if row_items in left_set
-        )
+        left_filtered = (row_items for row_items in left_set if row_items in right_set)
+        right_filtered = (row_items for row_items in right_set if row_items in left_set)
         return (
-            Row.from_mapping(row, _id=id)
-            for id, row in enumerate(itertools.chain(left_filtered, right_filtered))
+            Row.from_mapping(dict(row))
+            for row in itertools.chain(left_filtered, right_filtered)
         )
 
 
@@ -442,10 +435,10 @@ class Intersect(SetOperation):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         return (
-            Row.from_mapping(dict(row), _id=id)
-            for id, row in enumerate(self.itemize(self.left) & self.itemize(self.right))
+            Row.from_mapping(dict(row))
+            for row in self.itemize(self.left) & self.itemize(self.right)
         )
 
 
@@ -454,15 +447,12 @@ class Difference(SetOperation):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         right_set = self.itemize(self.right)
-        filtered = (
-            dict(row_items)
+        return toolz.unique(
+            Row.from_mapping(dict(row_items))
             for row_items in (tuple(row.items()) for row in self.left)
             if row_items not in right_set
-        )
-        return toolz.unique(
-            Row.from_mapping(row, _id=id) for id, row in enumerate(filtered)
         )
 
 
@@ -471,11 +461,10 @@ class DifferenceAll(SetOperation):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterator[AbstractRow]:
+    def _produce(self) -> Iterator[AbstractRow]:
         right_set = self.itemize(self.right)
-        filtered = (
-            dict(row_items)
+        return (
+            Row.from_mapping(dict(row_items))
             for row_items in (tuple(row.items()) for row in self.left)
             if row_items not in right_set
         )
-        return (Row.from_mapping(row, _id=id) for id, row in enumerate(filtered))

--- a/stupidb/core.py
+++ b/stupidb/core.py
@@ -55,9 +55,14 @@ class Relation(abc.ABC):
         """Iterate over the rows of a :class:`~stupidb.stupidb.Relation`."""
         return (row._renew_id(id) for id, row in enumerate(filter(None, self.child)))
 
+
+class Table(Relation):
+    __slots__ = ()
+
     @classmethod
     def from_iterable(cls, iterable: Iterable[Mapping[str, Any]]) -> Relation:
-        return cls(Row.from_mapping(row, _id=i) for i, row in enumerate(iterable))
+        """Construct a :class:`~stupidb.stupidb.Table` from an iterable."""
+        return cls(map(Row.from_mapping, iterable))
 
 
 FullProjector = Union_[Projector, WindowAggregateSpecification]

--- a/stupidb/row.py
+++ b/stupidb/row.py
@@ -33,7 +33,7 @@ class AbstractRow(Mapping[str, Any], Hashable, abc.ABC):
         self,
         piece: Mapping[str, Any],
         *pieces: Mapping[str, Any],
-        _id: int,
+        _id: int = -1,
         _hash: Optional[int] = None,
     ) -> None:
         """Construct an :class:`AbstractRow`.
@@ -118,7 +118,7 @@ class Row(AbstractRow):
         return self.pieces[0]
 
     @classmethod
-    def from_mapping(cls, mapping: Mapping[str, Any], *, _id: int) -> Row:
+    def from_mapping(cls, mapping: Mapping[str, Any], *, _id: int = -1) -> Row:
         """Construct a Row instance from any mapping with string keys.
 
         Parameters
@@ -163,7 +163,7 @@ class JoinedRow(AbstractRow):
         left: Mapping[str, Any],
         right: Mapping[str, Any],
         *,
-        _id: int,
+        _id: int = -1,
         _hash: Optional[None] = None,
     ) -> None:
         """Construct a :class:`JoinedRow` instance.

--- a/stupidb/row.py
+++ b/stupidb/row.py
@@ -118,7 +118,7 @@ class Row(AbstractRow):
         return self.pieces[0]
 
     @classmethod
-    def from_mapping(cls, mapping: Mapping[str, Any], *, _id: int = -1) -> Row:
+    def from_mapping(cls, mapping: Mapping[str, Any], *, _id: int = -1) -> AbstractRow:
         """Construct a Row instance from any mapping with string keys.
 
         Parameters
@@ -129,7 +129,11 @@ class Row(AbstractRow):
             A new row id for the returned :class:`Row` instance.
 
         """
-        return cls(getattr(mapping, "data", mapping), _id=_id)
+        return (
+            mapping._renew_id(_id)
+            if isinstance(mapping, AbstractRow)
+            else cls(getattr(mapping, "data", mapping), _id=_id)
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data})"

--- a/stupidb/tests/conftest.py
+++ b/stupidb/tests/conftest.py
@@ -46,14 +46,6 @@ def assert_rowset_equal(left, right):
 
 
 @pytest.fixture(scope="session")
-def test_table(rows):
-    expected = rows[:]
-    op = table(rows)
-    result = list(op)
-    assert_rowset_equal(result, expected)
-
-
-@pytest.fixture(scope="session")
 def t_rows():
     return [
         dict(name="alice", date=date(2018, 1, 1), balance=2),

--- a/stupidb/tests/test_animate.py
+++ b/stupidb/tests/test_animate.py
@@ -23,7 +23,7 @@ def test_main_default_args():
         subprocess.check_call(
             [f"{sys.executable}", "-m", "stupidb.animate", "-o", os.devnull]
         )
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError as e:  # pragma: no cover
         print(e.stderr, file=sys.stderr)
         raise
 
@@ -45,6 +45,6 @@ def test_main_custom_leaves():
                 "2",
             ]
         )
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError as e:  # pragma: no cover
         print(e.stderr, file=sys.stderr)
         raise

--- a/stupidb/tests/test_stupidb.py
+++ b/stupidb/tests/test_stupidb.py
@@ -250,12 +250,7 @@ def test_valid_limit(rows: Sequence[Mapping[str, Any]], offset: int, lim: int) -
 
 @pytest.mark.parametrize(  # type: ignore[misc]
     ("offset", "lim"),
-    (
-        (offset, lim)
-        for lim in range(-2, 1)
-        for offset in range(-2, 1)
-        if offset and lim
-    ),
+    ((offset, lim) for lim in range(-2, 1) for offset in range(-2, 1) if offset or lim),
 )
 def test_invalid_limit(
     rows: Sequence[Mapping[str, Any]],


### PR DESCRIPTION
- refactor(tests): remove dead test code
- test(coverage): don't cover things that are designed to be informative during testing
- test(limit): handle case where offset is valid and limit is not
- test: add more from_iterable failure tests
- refactor: default to -1 for row id to make construction less verbose
- refactor: return an abstract row from `from_mapping`
- refactor: introduce a Table class and move the from_iterable method there
- refactor: use the Table object in the table function
- refactor: implement a _produce method instead of __iter__ for less row munging
- refactor(api): expose public and hide private APIs in api.py
