### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a08a9b2fba56b23d4a076727ffa0c1e74f083e5",
-        "sha256": "0frzh8imwamgqi7m6w5j4nyarkvrgm80ic22wbbzci4nnn9p8h8q",
+        "rev": "330aeaff794f6f1453b2b0ffeb2e4decbcc0b265",
+        "sha256": "1j4y35bqd64xp3qn3i8vhykdxin7l97ic6daqrzfv1hk7ir5j7bq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7a08a9b2fba56b23d4a076727ffa0c1e74f083e5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/330aeaff794f6f1453b2b0ffeb2e4decbcc0b265.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 | Pull Requests                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`a24f4585`](https://github.com/NixOS/nixpkgs/commit/a24f458578d1b9d0b82a8194d62f7d1983f16552) | `elixir: 1.12.2 -> 1.12.3`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136854">#136854</a></li></ul> |
| [`391f22ea`](https://github.com/NixOS/nixpkgs/commit/391f22eae45b8d3a643c84f883234b68047ef1d5) | `perlPackages.CursesUIGrid: init at 0.15`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136907">#136907</a></li></ul> |
| [`526f87eb`](https://github.com/NixOS/nixpkgs/commit/526f87ebea97cafa1332d56fe32cd1b02c871b62) | `fondo: 1.5.2 -> 1.6.1`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136906">#136906</a></li></ul> |
| [`feee3a28`](https://github.com/NixOS/nixpkgs/commit/feee3a28e9231dbb549952308b58632535779039) | `python38Packages.xkcdpass: 1.19.2 -> 1.19.3`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136898">#136898</a></li></ul> |
| [`169acb38`](https://github.com/NixOS/nixpkgs/commit/169acb3808740476bdbb614c38f540aec616213f) | `just: 0.10.0 -> 0.10.1`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136885">#136885</a></li></ul> |
| [`e7feba35`](https://github.com/NixOS/nixpkgs/commit/e7feba356e81ea8a9ea1efa388e2957cceb8cd78) | `macchina: 1.0.0 -> 1.1.3`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136886">#136886</a></li></ul> |
| [`7632e207`](https://github.com/NixOS/nixpkgs/commit/7632e207ea4ab25d699632d97839fd27a6d56dec) | `hurl: 1.2.0 -> 1.3.0`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136876">#136876</a></li></ul> |
| [`4f4ab52f`](https://github.com/NixOS/nixpkgs/commit/4f4ab52f4fde7d831e3dad4cd91f1da30a3d0ae8) | `freeimage: support cross-compilation`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136870">#136870</a></li></ul> |
| [`997ad14b`](https://github.com/NixOS/nixpkgs/commit/997ad14b0deae498c720b1a95da6407bf632ec04) | `newsflash: 1.4.2 -> 1.4.3`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136874">#136874</a></li></ul> |
| [`99e969ab`](https://github.com/NixOS/nixpkgs/commit/99e969ab15023d5a9565c8b6acd5575520d48abd) | `himalaya-vim: fix broken build`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136872">#136872</a></li></ul> |
| [`f5a162c2`](https://github.com/NixOS/nixpkgs/commit/f5a162c2cae1c487c2ad058994c85ac392fc840c) | `go-task: 3.7.0 -> 3.7.3`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136871">#136871</a></li></ul> |
| [`954439a8`](https://github.com/NixOS/nixpkgs/commit/954439a81b9c5d5a57ea37aa176c7751adaa49ee) | `folly: 2021.08.23.00 -> 2021.08.30.00`                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136868">#136868</a></li></ul> |
| [`590b7242`](https://github.com/NixOS/nixpkgs/commit/590b724277597c7a20a6df7a2b4fde9cd2904e5f) | `flow: 0.158.0 -> 0.159.0`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136866">#136866</a></li></ul> |
| [`d4a0f34c`](https://github.com/NixOS/nixpkgs/commit/d4a0f34cceacfea469355550379f0bae8e9e6fbc) | `mu: 1.6.5 -> 1.6.6`                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136864">#136864</a></li></ul> |
| [`1494a69e`](https://github.com/NixOS/nixpkgs/commit/1494a69e0cfa20b718bbf18f4ee89e461d2de94c) | `featherpad: 0.18.0 -> 1.0.0`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136861">#136861</a></li></ul> |
| [`588b8cec`](https://github.com/NixOS/nixpkgs/commit/588b8cec0e57901007ea37fe00e5258988b2a57b) | `python3Packages.async-upnp-client: 0.20.0 -> 0.21.0`                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136858">#136858</a></li></ul> |
| [`cdbc8c9f`](https://github.com/NixOS/nixpkgs/commit/cdbc8c9fb1aeb198e20a63782c0e8b40155afce8) | `ocamlPackages.parsexp: 0.14.0 → 0.14.1`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136220">#136220</a></li></ul> |
| [`5dd6ff76`](https://github.com/NixOS/nixpkgs/commit/5dd6ff76a5fa7893561d5b8808d5d921b013c9a7) | `esbuild: 0.12.24 -> 0.12.25`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136855">#136855</a></li></ul> |
| [`30a7899e`](https://github.com/NixOS/nixpkgs/commit/30a7899eed026c1f42438207a9626c2647a7f2cb) | `elinks: 0.14.1 -> 0.14.2`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136853">#136853</a></li></ul> |
| [`46604eec`](https://github.com/NixOS/nixpkgs/commit/46604eec55e2c88dc439c8e1f7d56cf71d921f90) | `python38Packages.django-jinja: 2.9.0 -> 2.9.1`                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136846">#136846</a></li></ul> |
| [`49cce41b`](https://github.com/NixOS/nixpkgs/commit/49cce41b7c5f6b88570a482355d9655ca19c1029) | `tree-sitter: update grammars`                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136844">#136844</a></li></ul> |
| [`9fcf2a8a`](https://github.com/NixOS/nixpkgs/commit/9fcf2a8a2cb0f5b78edc8ec7ca877240e7fe3009) | `lima: 0.6.2 -> 0.6.3`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136834">#136834</a></li></ul> |
| [`87c6a8a7`](https://github.com/NixOS/nixpkgs/commit/87c6a8a7066117f547f05fcc678db4119059bbd9) | `envsubst: drive-by cleanup`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136767">#136767</a></li></ul> |
| [`5e47a07e`](https://github.com/NixOS/nixpkgs/commit/5e47a07e9f2d7ed999f2c7943b0896f5f7321ca3) | `pkgs/tracy: fix on Darwin`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136818">#136818</a></li></ul> |
| [`85763b63`](https://github.com/NixOS/nixpkgs/commit/85763b63cc24286b11e93ea118dc4195ad511a76) | `caddy: 2.4.4 -> 2.4.5`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136740">#136740</a></li></ul> |
| [`d8ef13fc`](https://github.com/NixOS/nixpkgs/commit/d8ef13fc13974b1406fd8aa9afd683f91c522052) | `modules/programs/command-not-found: Fix ShellCheck warnings`                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136727">#136727</a></li></ul> |
| [`d44b6ae6`](https://github.com/NixOS/nixpkgs/commit/d44b6ae6cb4d262b7281896df6f79fba04b67837) | `modules/programs/bash: Fix ShellCheck warnings`                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136727">#136727</a></li></ul> |
| [`b27bd16b`](https://github.com/NixOS/nixpkgs/commit/b27bd16bd95e64966e881def7f95968e84a9aaea) | `poetry2conda: init at 0.3.0`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136372">#136372</a></li></ul> |
| [`960f59ba`](https://github.com/NixOS/nixpkgs/commit/960f59ba72e533430d4c61fa8d9d070a53d58e36) | `poetry-semver: init at 0.1.0`                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136372">#136372</a></li></ul> |
| [`e4cb871e`](https://github.com/NixOS/nixpkgs/commit/e4cb871eafe121e14cea80899bb3ee30814fa0a7) | `python3Packages.bitarray: 2.3.2 -> 2.3.3`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136816">#136816</a></li></ul> |
| [`030bed20`](https://github.com/NixOS/nixpkgs/commit/030bed204a4c9beffa1e8126624b0b92d217b904) | `python3Packages.pyvicare: 2.7.1 -> 2.8`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136815">#136815</a></li></ul> |
| [`f1312d51`](https://github.com/NixOS/nixpkgs/commit/f1312d514d0d5d4c2254fb7f8a9a4388a6cd1145) | `git-cliff: init at 0.2.6`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136814">#136814</a></li></ul> |
| [`36d6673c`](https://github.com/NixOS/nixpkgs/commit/36d6673cf865bc80f7c383980b597eae077122dd) | `libjxl: fix for hydra's darwin builder`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136795">#136795</a></li></ul> |
| [`560f823e`](https://github.com/NixOS/nixpkgs/commit/560f823ebb24f40381b1f2972302f2dd913647ca) | `python3Packages.bidict: 0.21.2 -> 0.21.3`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136812">#136812</a></li></ul> |
| [`8666c95a`](https://github.com/NixOS/nixpkgs/commit/8666c95a0e66f91ba3d67d0d31e1c04c2c12035f) | `grafana: add meta.mainProgram`                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136811">#136811</a></li></ul> |
| [`03637fe5`](https://github.com/NixOS/nixpkgs/commit/03637fe5869c1f854ad05c6d301812eda3ac1761) | `sdlpop: 1.21 -> 1.22`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136808">#136808</a></li></ul> |
| [`732316e9`](https://github.com/NixOS/nixpkgs/commit/732316e9c571d17eb039bfecfc3604738bba33ad) | `vikunja-api: 0.17.1 -> 0.18.0`                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136801">#136801</a></li></ul> |
| [`e0fbad9a`](https://github.com/NixOS/nixpkgs/commit/e0fbad9a66714bcace29ff34e65573e9d6a0bec0) | `vikunja-frontend: 0.17.0 -> 0.18.0`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136801">#136801</a></li></ul> |
| [`39688bfb`](https://github.com/NixOS/nixpkgs/commit/39688bfb41799c5e836128b3126e966ab3585c6c) | `knot-dns: upstream patch that should fix aarch64-darwin`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136799">#136799</a></li></ul> |
| [`9a4bdda2`](https://github.com/NixOS/nixpkgs/commit/9a4bdda26e77168d81023a6abf835dda46bb51c8) | `libjxl: unstable-2021-06-22 -> 0.5`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136795">#136795</a></li></ul> |
| [`9f98d0df`](https://github.com/NixOS/nixpkgs/commit/9f98d0df442edd8c34898536b57e265ea3969d04) | `zellij: 0.15.0 -> 0.16.0`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136281">#136281</a></li></ul> |
| [`ca6cb24b`](https://github.com/NixOS/nixpkgs/commit/ca6cb24b966832c851c01754e069edfe7bccaa77) | `foot: 1.8.2 -> 1.9.0`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135911">#135911</a></li></ul> |
| [`51c4e675`](https://github.com/NixOS/nixpkgs/commit/51c4e675e293a172ad8d3a84ef99497067841601) | `google-cloud-sdk: add meta.mainProgram (#136713)`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136713">#136713</a></li></ul> |
| [`7559cd66`](https://github.com/NixOS/nixpkgs/commit/7559cd66012025da118062d3c8b32dbfc4a9d41e) | `bamf: 0.5.4 -> 0.5.5`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136750">#136750</a></li></ul> |
| [`01920016`](https://github.com/NixOS/nixpkgs/commit/019200160c257bf5cd4880d2501e03c9868ed89b) | `python3Packages.numpy-stl: use pytestCheckHook`                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136775">#136775</a></li></ul> |
| [`420797fe`](https://github.com/NixOS/nixpkgs/commit/420797fe78cef3c38e724492a32230020f37ce42) | `sstp: rename phase`                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135965">#135965</a></li></ul> |
| [`d705ef65`](https://github.com/NixOS/nixpkgs/commit/d705ef6521cfc764d9028d0ab8f51618c37ec69a) | `sstp: clarify license`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135965">#135965</a></li></ul> |
| [`4dd783a1`](https://github.com/NixOS/nixpkgs/commit/4dd783a187f71a6735867820233cd50e62f610b3) | `pax-utils: clarify license`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136055">#136055</a></li></ul> |
| [`b85d9176`](https://github.com/NixOS/nixpkgs/commit/b85d91762a73624ce283528d7201a5e0785dd5e6) | `cramfsprogs: support cross-compilation`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136773">#136773</a></li></ul> |
| [`29cd399d`](https://github.com/NixOS/nixpkgs/commit/29cd399d805c66510c097fe1f79c142c9ddc504d) | `python3Packages.python-nomad: add pythonImportsCheck`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136423">#136423</a></li></ul> |
| [`434b9bde`](https://github.com/NixOS/nixpkgs/commit/434b9bde936866887c7fa9f9fa7c080d56e352eb) | `rdfind: clarify license`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136764">#136764</a></li></ul> |
| [`b2480d25`](https://github.com/NixOS/nixpkgs/commit/b2480d258065a34a4d8ee50f3e5e53b4cea8ed9a) | `qownnotes: 21.7.4 -> 21.8.12 (#135941)`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135941">#135941</a></li></ul> |
| [`219d3e43`](https://github.com/NixOS/nixpkgs/commit/219d3e437e55741d7d8e2ce1265ba48b0e05afd0) | `sasquatch: support cross-compilation`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136772">#136772</a></li></ul> |
| [`c32fa3f1`](https://github.com/NixOS/nixpkgs/commit/c32fa3f108532b19b6482078dc10b99f752001f2) | `intel-gmmlib: add x686-linux to meta.platforms (#136738)`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136738">#136738</a></li></ul> |
| [`e507ca59`](https://github.com/NixOS/nixpkgs/commit/e507ca593330a24f0de49cdeb60d4074e5bb3ab9) | `timetable: drop package`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136768">#136768</a></li></ul> |
| [`7dc83f03`](https://github.com/NixOS/nixpkgs/commit/7dc83f03fa341ddb5743e28ca3a0866b6a8d4790) | `python3Packages.simplisafe-python: 11.0.5 -> 11.0.6`                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136759">#136759</a></li></ul> |
| [`4a49353e`](https://github.com/NixOS/nixpkgs/commit/4a49353e9b2bd896c13c826a70dc49686363cb74) | `rdfind: 1.4.1 -> 1.5.0`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136764">#136764</a></li></ul> |
| [`7357a87d`](https://github.com/NixOS/nixpkgs/commit/7357a87d93e090d32971a93fc4d46e5f59888605) | `python3Packages.pyezviz: 0.1.9.2 -> 0.1.9.3`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136757">#136757</a></li></ul> |
| [`1b4038bd`](https://github.com/NixOS/nixpkgs/commit/1b4038bddfac009f0eccf516e4874219bfc331d2) | `linux_zen: 5.13.13-zen1 -> 5.14.1-zen1`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136752">#136752</a></li></ul> |
| [`2d1908ac`](https://github.com/NixOS/nixpkgs/commit/2d1908ac0b1c32cfa2e793212b9f10d0f7be75ea) | `xplr: 0.14.5 -> 0.14.7`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136745">#136745</a></li></ul> |
| [`3af3ca8c`](https://github.com/NixOS/nixpkgs/commit/3af3ca8cc23b771c2550c54f6dfcc0b9952052d0) | `perlPackages.PkgConfig: fix cross compilation`                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136700">#136700</a></li></ul> |
| [`7bf2ada3`](https://github.com/NixOS/nixpkgs/commit/7bf2ada396bc4856e2b7d46df37a36d0bdd49d3a) | `neovim-ruby: 0.8.0 -> 0.8.1`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136769">#136769</a></li></ul> |
| [`6a53e71d`](https://github.com/NixOS/nixpkgs/commit/6a53e71df9c65ce4972f16945ffb3a007ba3e1de) | `libopenmpt: split lib and dev output`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136735">#136735</a></li></ul> |
| [`95947e73`](https://github.com/NixOS/nixpkgs/commit/95947e7346092ec82d724799ba0424c365dbd86b) | `gst_all_1.gst-plugins-bad: enable libopenmtp`                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136735">#136735</a></li></ul> |
| [`347caa97`](https://github.com/NixOS/nixpkgs/commit/347caa97751457c34ba2cec85562a27d5dbba662) | `treewide: rename openmpt123 to libopenmpt to match the name in other distros` | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136735">#136735</a></li></ul> |
| [`ae7696d3`](https://github.com/NixOS/nixpkgs/commit/ae7696d378d69855f77839c09f032a4d90ed07ba) | `ocamlPackages.visitors: 20210316 -> 20210608`                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136734">#136734</a></li></ul> |
| [`281b181a`](https://github.com/NixOS/nixpkgs/commit/281b181afb579cd99def2396c0c6314757de24a5) | `lxd: 4.17 -> 4.18`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136731">#136731</a></li></ul> |
| [`b7ff943c`](https://github.com/NixOS/nixpkgs/commit/b7ff943c405f8479eb59f1d71b8bdb230a204b75) | `postgresqlPackages.postgis: 3.1.3 -> 3.1.4`                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136730">#136730</a></li></ul> |
| [`62ad139d`](https://github.com/NixOS/nixpkgs/commit/62ad139d87c08fc4efd4b04ba38f698f910f1217) | `telescope: 0.4.1 -> 0.5.1`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136669">#136669</a></li></ul> |
| [`da0626ca`](https://github.com/NixOS/nixpkgs/commit/da0626cad7513b0d2fb603107051edd8a4dc377f) | `sad: init at 0.4.14`                                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136663">#136663</a></li></ul> |
| [`a53cae02`](https://github.com/NixOS/nixpkgs/commit/a53cae021ab54d9bcbdadffb98a063ef36ef3858) | `android-studio: 2020.3.1.23 → 2020.3.1.24`                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136606">#136606</a></li></ul> |
| [`ed471ccf`](https://github.com/NixOS/nixpkgs/commit/ed471ccf22e3bc11de7f67f7ba89c948d20003f0) | `tortoisehg: 5.8 -> 5.9`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136595">#136595</a></li></ul> |
| [`c418c4f8`](https://github.com/NixOS/nixpkgs/commit/c418c4f8c6d4fc35c6381e5da430e2b17f2c3145) | `mercurial: 5.8 -> 5.9.1`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136595">#136595</a></li></ul> |
| [`99eafb13`](https://github.com/NixOS/nixpkgs/commit/99eafb132b67f4ae2e04fbdc4455277167a32c4b) | `singularity: 3.8.1 -> 3.8.2`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136438">#136438</a></li></ul> |
| [`d3a994ea`](https://github.com/NixOS/nixpkgs/commit/d3a994ea5f4e8b80de4eeae70fca58f07d2144ea) | `python38Packages.python-nomad: 1.2.1 -> 1.3.0`                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136423">#136423</a></li></ul> |
| [`5ea6fde0`](https://github.com/NixOS/nixpkgs/commit/5ea6fde01160311e88859343461c7147a114bbfe) | `python38Packages.numpy-stl: 2.16.0 -> 2.16.2`                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136411">#136411</a></li></ul> |
| [`25bc11e4`](https://github.com/NixOS/nixpkgs/commit/25bc11e43b5be36fc205f08739f53f8adc191fbb) | `python38Packages.exchangelib: 4.5.0 -> 4.5.1`                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136393">#136393</a></li></ul> |
| [`10ba2633`](https://github.com/NixOS/nixpkgs/commit/10ba2633e48d31e03cd9d666e6a7e0ec3b0c8b73) | `python38Packages.cogapp: 3.0.0 -> 3.1.0`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136370">#136370</a></li></ul> |
| [`4cacbf47`](https://github.com/NixOS/nixpkgs/commit/4cacbf474659a9bb5af4ad8a8474f2dfda2067cf) | `fig2dev: 3.2.8a -> 3.2.8b`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136364">#136364</a></li></ul> |
| [`5f16358e`](https://github.com/NixOS/nixpkgs/commit/5f16358e015926e2cb980102cd1d160b8a3ae28a) | `python3Packages.uproot: 4.0.8 -> 4.1.1`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136361">#136361</a></li></ul> |
| [`f452146d`](https://github.com/NixOS/nixpkgs/commit/f452146df8a5b6ac8920ddecbcec41a817dffff0) | `cowpatty: 4.6 -> 4.8`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136335">#136335</a></li></ul> |
| [`a693aca2`](https://github.com/NixOS/nixpkgs/commit/a693aca24d35d1f560b47c74820ac4a779b024ef) | `pax-utils: 1.2.8 -> 1.3.3`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136055">#136055</a></li></ul> |
| [`53b91749`](https://github.com/NixOS/nixpkgs/commit/53b917498bc2887c0a6f99a61fbb8fe1665e574c) | `winetricks: 20210206 -> 20210825`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136044">#136044</a></li></ul> |
| [`bfeebdf0`](https://github.com/NixOS/nixpkgs/commit/bfeebdf0fac06f13927a8f7d62ba5ba49109d1aa) | `sstp: 1.0.13 -> 1.0.15`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135965">#135965</a></li></ul> |
| [`477dc156`](https://github.com/NixOS/nixpkgs/commit/477dc156477ef10650ca3a5a5e41be61ade6e3f6) | `tempo: 1.0.1 -> 1.1.0`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135918">#135918</a></li></ul> |
| [`13a1ac54`](https://github.com/NixOS/nixpkgs/commit/13a1ac5421780914bb35569a72956b8c5bf90c54) | `luajit_2_0: make it unsupported on all aarch64 platform variants`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`737e7314`](https://github.com/NixOS/nixpkgs/commit/737e7314bc754c67fd896e69601189251bf06c09) | `luajit_2_1: 2.1.0-2021-06-25 -> 2.1.0-2021-08-12`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`d1d5367d`](https://github.com/NixOS/nixpkgs/commit/d1d5367da79f327007c9069880f8ca23bf966de3) | `luajit_2_0: 2.1.0-2021-06-08 -> 2.1.0-2021-07-27`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`fff205f4`](https://github.com/NixOS/nixpkgs/commit/fff205f4a31f2960c4daf8b5810200473b20d53e) | `neovim: use luajit on aarch64-darwin`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`96347847`](https://github.com/NixOS/nixpkgs/commit/9634784777d48ce6352c0a7cd7ebde5abbd02ef3) | `luajit: disable unwind external on aarch64-darwin`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`d01533ce`](https://github.com/NixOS/nixpkgs/commit/d01533ceabdd84674a90691969bf4294e9d97ce1) | `pkgsCross.avr.buildPackages.gcc{10,11}: avoid log limit on hydra`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135692">#135692</a></li></ul> |
| [`a15ee484`](https://github.com/NixOS/nixpkgs/commit/a15ee4845bec7dd5dfe74971d23b788cb2d49885) | `luajit: format with nixpkgs-fmt`                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`d5fe0d2b`](https://github.com/NixOS/nixpkgs/commit/d5fe0d2b6e2117b08d5c1adac86a2e42ca93c5c5) | `Revert "luajit_openresty: init"`                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`20b48c37`](https://github.com/NixOS/nixpkgs/commit/20b48c37275fe931a46233a7f3f2cb6aa8cf68e2) | `Revert "neovim: use luajit_openresty on aarch64-darwin"`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135672">#135672</a></li></ul> |
| [`ec0dc734`](https://github.com/NixOS/nixpkgs/commit/ec0dc734c3f0644ea653749eb65c368a66025c5e) | `python3Packages.hg-commitsigs: init at unstable-2021-01-08`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/122318">#122318</a></li></ul> |