### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "330aeaff794f6f1453b2b0ffeb2e4decbcc0b265",
-        "sha256": "1j4y35bqd64xp3qn3i8vhykdxin7l97ic6daqrzfv1hk7ir5j7bq",
+        "rev": "10ce023e3d9c49111a05acb42930535b9d43097d",
+        "sha256": "1nja06dibv76md8b5rpz6mmydx2f4537dcflar6npg3x33s9qwcp",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/330aeaff794f6f1453b2b0ffeb2e4decbcc0b265.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/10ce023e3d9c49111a05acb42930535b9d43097d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          | Pull Requests                                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`82d19cb0`](https://github.com/NixOS/nixpkgs/commit/82d19cb068d7213c8beaa96220f1d81d57a28381) | `vimPlugins: fix update script`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137002">#137002</a></li></ul> |
| [`d05a0f9c`](https://github.com/NixOS/nixpkgs/commit/d05a0f9cea9428be209231a51dbff7d9b877fe23) | `vimPlugins.vim-toml: fix branch name`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136999">#136999</a></li></ul> |
| [`6ffa6c67`](https://github.com/NixOS/nixpkgs/commit/6ffa6c67c95fdf65e503027cf7d605771c569291) | `ardour: 6.7 -> 6.9 (#136694)`                                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136694">#136694</a></li></ul> |
| [`659c60af`](https://github.com/NixOS/nixpkgs/commit/659c60af7c28cd61512f809a040cc0477e1a96d3) | `fftw: allow for optional MPI build`                                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137000">#137000</a></li></ul> |
| [`0d4dd66d`](https://github.com/NixOS/nixpkgs/commit/0d4dd66d6e22bf4861dd3ccd2ec6635c1c57e506) | `obsidian: pin electron 13`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136995">#136995</a></li></ul> |
| [`c863de29`](https://github.com/NixOS/nixpkgs/commit/c863de29a77c201bf93626bc29d185d3bb185338) | `nixos/doc/md-to-db.sh: handle Docbook inclues in CommonMark`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136987">#136987</a></li></ul> |
| [`459957f9`](https://github.com/NixOS/nixpkgs/commit/459957f9d4d2e82424c7819eb36de4ec7644ef8d) | `nixos/documentation: expose manualPages`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136915">#136915</a></li></ul> |
| [`11aedaec`](https://github.com/NixOS/nixpkgs/commit/11aedaec1f545d6b02cbe5fedc79629ee1dca557) | `nixos: nix.sshServe: add write option`                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136703">#136703</a></li></ul> |
| [`bf18449d`](https://github.com/NixOS/nixpkgs/commit/bf18449d63edbb6b198fb06c49516cec10979bad) | `sile: 0.10.5 → 0.11.1`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136453">#136453</a></li></ul> |
| [`9d753f27`](https://github.com/NixOS/nixpkgs/commit/9d753f27043a2c513e89e1317bde186119b51411) | `lua-penlight: dev-1 → 1.11.0-1`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136453">#136453</a></li></ul> |
| [`23ab07cc`](https://github.com/NixOS/nixpkgs/commit/23ab07cc245a3c26d8fe7a92d293c53315abe4eb) | `exa: re-enable documentation build on aarch64-darwin`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136963">#136963</a></li></ul> |
| [`21a7695b`](https://github.com/NixOS/nixpkgs/commit/21a7695b8afb29c17ff47fbc0f4798b5a56ac23a) | `mirakurun: build with yarn2nix`                                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136794">#136794</a></li></ul> |
| [`9cbdd265`](https://github.com/NixOS/nixpkgs/commit/9cbdd2655c340363f00fdb784015d495aac007d6) | `elasticsearch: auto_import_dangling_indices in single-node mode`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136900">#136900</a></li></ul> |
| [`f4b40d57`](https://github.com/NixOS/nixpkgs/commit/f4b40d572ce50503136896bdd0501f35584b7da0) | `elasticsearch: update configuration`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136900">#136900</a></li></ul> |
| [`ebd5774d`](https://github.com/NixOS/nixpkgs/commit/ebd5774d272fc52a7ca0da667014f8fec90f6cd8) | `Duplicated shell-command-plus - manual fixup`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136953">#136953</a></li></ul> |
| [`1f369b3f`](https://github.com/NixOS/nixpkgs/commit/1f369b3fe3f6571c9680054a08ac56b79be4c9aa) | `elpa-packages 2021-09-06`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136953">#136953</a></li></ul> |
| [`474298bb`](https://github.com/NixOS/nixpkgs/commit/474298bb9b17051b37e3cec86b932a5cc24282c0) | `melpa-packages 2021-09-06`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136953">#136953</a></li></ul> |
| [`11690420`](https://github.com/NixOS/nixpkgs/commit/11690420086874e479002a04ffba6faae37b432f) | `nongnu-packages 2021-09-06`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136953">#136953</a></li></ul> |
| [`45f2cb50`](https://github.com/NixOS/nixpkgs/commit/45f2cb502b6f476d4dc86df22fa0e218cd4e41f4) | `org-packages 2021-09-06`                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136953">#136953</a></li></ul> |
| [`1195d52a`](https://github.com/NixOS/nixpkgs/commit/1195d52ad7587390f26447302924473b7a11996c) | `Update comments about automatic generation of elisp packages`                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136953">#136953</a></li></ul> |
| [`6af74c9f`](https://github.com/NixOS/nixpkgs/commit/6af74c9ff8b03dd885246e46c01447adea529424) | `rPackages.ssh: include missing libssh buildInput`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136947">#136947</a></li></ul> |
| [`89c37a09`](https://github.com/NixOS/nixpkgs/commit/89c37a0988787966983727f354e0f281e1070d97) | `haskell.compiler.ghc921: remove darwin from hydraPlatforms since it is broken`         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`1823f8f0`](https://github.com/NixOS/nixpkgs/commit/1823f8f0cd3f1ef0e9a3ff38f9ca3ed57670d5da) | `tts: 0.2.1 -> 0.2.2`                                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136943">#136943</a></li></ul> |
| [`9b8b11e2`](https://github.com/NixOS/nixpkgs/commit/9b8b11e25f9a8d27948a822748608a1a81e05d69) | `haskellPackages: mark builds failing on hydra as broken`                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`e864d443`](https://github.com/NixOS/nixpkgs/commit/e864d443befc09b25816629c81758ee997f4bc83) | `python3Packages.pontos: init at 21.7.4`                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136941">#136941</a></li></ul> |
| [`bccb9332`](https://github.com/NixOS/nixpkgs/commit/bccb933206a2b10bdacfc481b1f48c60878ec3af) | `home-assistant: enable youless tests`                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136939">#136939</a></li></ul> |
| [`5df4645b`](https://github.com/NixOS/nixpkgs/commit/5df4645b39280ab25a2147b58484d512a4734a0c) | `gitty: init at 0.3.0`                                                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136940">#136940</a></li></ul> |
| [`688e7ade`](https://github.com/NixOS/nixpkgs/commit/688e7ade2cce7df57c363d2199cce19e9a3d23c4) | `home-assistant: update component-packages`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136939">#136939</a></li></ul> |
| [`d697b79d`](https://github.com/NixOS/nixpkgs/commit/d697b79dcec9636466e01665341e57a063d944ea) | `python3Packages.youless-api: init at 0.12`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136939">#136939</a></li></ul> |
| [`4f0bc6d7`](https://github.com/NixOS/nixpkgs/commit/4f0bc6d71d1fbabf6e1684035290b65893982da5) | `vimPlugins: minimap-vim: fix plugin paths`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136930">#136930</a></li></ul> |
| [`4334e1cd`](https://github.com/NixOS/nixpkgs/commit/4334e1cd8746a0f46a6fe4faefaec31a17beb4b9) | `python3Packages.boschshcpy: 0.2.19 -> 0.2.20`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136935">#136935</a></li></ul> |
| [`f5a0c96b`](https://github.com/NixOS/nixpkgs/commit/f5a0c96b9a50a40a77f955a699802e27585384e1) | `fuse3: 3.10.4 -> 3.10.5`                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136934">#136934</a></li></ul> |
| [`a9fe9e8a`](https://github.com/NixOS/nixpkgs/commit/a9fe9e8a327d0a7bd8d3ab81c21533200fa10679) | `age: set and check version`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136919">#136919</a></li></ul> |
| [`6ea3694f`](https://github.com/NixOS/nixpkgs/commit/6ea3694fd0ffa72cb659125319e9f3c4df453c62) | `calamares: 3.2.39 -> 3.2.42`                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136929">#136929</a></li></ul> |
| [`43ff4fde`](https://github.com/NixOS/nixpkgs/commit/43ff4fde4385e5d438f0502215a8f3a28476efd0) | `reckon: 0.7.1 -> 0.8.0`                                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136928">#136928</a></li></ul> |
| [`a9dacd43`](https://github.com/NixOS/nixpkgs/commit/a9dacd437f2a87978a429a05f92009eb99d943de) | `freeciv: wrap gtkClient`                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136905">#136905</a></li></ul> |
| [`fec3f49b`](https://github.com/NixOS/nixpkgs/commit/fec3f49bfe9d5dfa50803e19a3ee6dd3d4acdb25) | `lispPackages: add varjo package and dependencies`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136927">#136927</a></li></ul> |
| [`48082af9`](https://github.com/NixOS/nixpkgs/commit/48082af9b89c4f662be46862e8199fe6b8b885bf) | `freeciv: do not enable gtkClient always on linux`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136905">#136905</a></li></ul> |
| [`7a6bddc1`](https://github.com/NixOS/nixpkgs/commit/7a6bddc19d9f6c93b1fb70305a8633da5215d9a7) | `lispPackages: sort quicklisp packages alphabetically`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136927">#136927</a></li></ul> |
| [`05cb210e`](https://github.com/NixOS/nixpkgs/commit/05cb210e9fa637a3926caa230b3b2800489d630a) | `black: remove appdirs dependency`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136792">#136792</a></li></ul> |
| [`469c02a5`](https://github.com/NixOS/nixpkgs/commit/469c02a52b4ac58c231d36686a28b2a1c3587373) | `black: 21.7b0 -> 21.8b0`                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136792">#136792</a></li></ul> |
| [`d4ab63cc`](https://github.com/NixOS/nixpkgs/commit/d4ab63cc2a624184718c6be9492ecb55839e36ee) | `pathspec: 0.8.1 -> 0.9.0`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136792">#136792</a></li></ul> |
| [`fabddcd7`](https://github.com/NixOS/nixpkgs/commit/fabddcd7b6a43f47c3fcfbcd890407b31e6eaa0d) | `age: 1.0.0-rc.3 -> 1.0.0`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136919">#136919</a></li></ul> |
| [`fbf7db7a`](https://github.com/NixOS/nixpkgs/commit/fbf7db7aeddc199d05d6e9953d173e32f07da565) | `haskellPackages.isocline: don't execute flawed test suite`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`e473a73e`](https://github.com/NixOS/nixpkgs/commit/e473a73eed41d3d40d0477e12ce908dd84369ee7) | `kaidan: add long description`                                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136916">#136916</a></li></ul> |
| [`2df0c2aa`](https://github.com/NixOS/nixpkgs/commit/2df0c2aae5a7ad685fa21da91007d1a89538f722) | `protontricks: 1.5.2 → 1.6.0`                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136910">#136910</a></li></ul> |
| [`8f91e36e`](https://github.com/NixOS/nixpkgs/commit/8f91e36ee8f5d8fc6e815498a2d7840775f36e0f) | `libplctag: 2.3.6 -> 2.3.7`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136896">#136896</a></li></ul> |
| [`b54f3e1e`](https://github.com/NixOS/nixpkgs/commit/b54f3e1e6f7294665bba1d7d3a8a6c586bef5672) | `liblouis: 3.18.0 -> 3.19.0`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136895">#136895</a></li></ul> |
| [`a58a90aa`](https://github.com/NixOS/nixpkgs/commit/a58a90aaa472bb4509d1dcc00c535a62f9461bf7) | `python38Packages.pybullet: 3.1.7 -> 3.1.8`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136884">#136884</a></li></ul> |
| [`416dcd45`](https://github.com/NixOS/nixpkgs/commit/416dcd451bbddab83feda367dc41a194fb2a8e66) | `jbang: 0.78.0 -> 0.79.0`                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136882">#136882</a></li></ul> |
| [`dc123187`](https://github.com/NixOS/nixpkgs/commit/dc1231876bd968937b7d5c58a146954a811e74e0) | `imath: 3.1.2 -> 3.1.3`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136880">#136880</a></li></ul> |
| [`b597dcf1`](https://github.com/NixOS/nixpkgs/commit/b597dcf1bcc12ef51f92cd9cfde59e91d0a7ca61) | `hydrogen: 1.0.2 -> 1.1.0`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136878">#136878</a></li></ul> |
| [`074ef76e`](https://github.com/NixOS/nixpkgs/commit/074ef76e99b3d54ef4804bbc1f37122721cd2b18) | `vcsh: 1.20170915 → 2.0.2`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136720">#136720</a></li></ul> |
| [`07557e3b`](https://github.com/NixOS/nixpkgs/commit/07557e3b49e77c42fc3e51e9e95451187dcd2d33) | `lua-cassowary: 2.3.1-1 → 2.3.1-2`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136453">#136453</a></li></ul> |
| [`36790b2c`](https://github.com/NixOS/nixpkgs/commit/36790b2c242500b70b201ca2f43ddddf2bb76af4) | `fbcat: 0.5.1 -> 0.5.2`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136860">#136860</a></li></ul> |
| [`6b1374eb`](https://github.com/NixOS/nixpkgs/commit/6b1374ebbdd4444457454b360810c32f697001ca) | `faudio: 21.08 -> 21.09`                                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136859">#136859</a></li></ul> |
| [`d06f8fcc`](https://github.com/NixOS/nixpkgs/commit/d06f8fcc394cd8363c6cd2423d3fed9f6e297845) | `liblinear: fix static build`                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136849">#136849</a></li></ul> |
| [`10a95914`](https://github.com/NixOS/nixpkgs/commit/10a959149e77b09bd350b112bfa70ef3db2fb926) | `cppzmq: 4.7.1 -> 4.8.0`                                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136845">#136845</a></li></ul> |
| [`53d26fbf`](https://github.com/NixOS/nixpkgs/commit/53d26fbfba153b4d4e01dfdc1c3bc93558c13c93) | `siduck76-st: init at 0.0.0+unstable=2021-08-20`                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136744">#136744</a></li></ul> |
| [`ba282124`](https://github.com/NixOS/nixpkgs/commit/ba2821244fd62899355797ca7a5c17d414d96ccf) | `mcaimi-st: init at 0.0.0+unstable=2021-08-30`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136744">#136744</a></li></ul> |
| [`2312cef1`](https://github.com/NixOS/nixpkgs/commit/2312cef179544db7bedf6c9464a12ad41cd7eea6) | `lukesmithxyz-st: init at 0.0.0+unstable=2021-08-10`                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136744">#136744</a></li></ul> |
| [`ffbdbef3`](https://github.com/NixOS/nixpkgs/commit/ffbdbef39a76fb4e6f10d7b407c69dfe777f675f) | `chafa: 1.6.1 -> 1.8.0`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136836">#136836</a></li></ul> |
| [`ba3631c0`](https://github.com/NixOS/nixpkgs/commit/ba3631c05593813a1bd30519c10a6d1e8c3ffd21) | `cfssl: 1.6.0 -> 1.6.1`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136835">#136835</a></li></ul> |
| [`bf7f1648`](https://github.com/NixOS/nixpkgs/commit/bf7f16485bf13bd88c35d25338348935407f50bc) | `cargo-tarpaulin: 0.18.0 -> 0.18.2`                                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136833">#136833</a></li></ul> |
| [`0b31008a`](https://github.com/NixOS/nixpkgs/commit/0b31008a5205cf266a9d2efd0c1d7ea304d04d51) | `brave: 1.28.106 -> 1.29.77`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136830">#136830</a></li></ul> |
| [`ac461b81`](https://github.com/NixOS/nixpkgs/commit/ac461b815edf7060e2570cf0fc4d9299831d0141) | `bibletime: 3.0.1 -> 3.0.2`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136829">#136829</a></li></ul> |
| [`93c06e23`](https://github.com/NixOS/nixpkgs/commit/93c06e23f295118c6c3ed6ac54f8aa6a67948852) | `hadolint: build with language-docker 10.1.1`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`b3da6961`](https://github.com/NixOS/nixpkgs/commit/b3da6961d5a4ace1fa93f3deff8f581d25bfec75) | `docs: haskell-updates/HACKING.md: Add link to chat`                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`69e85c1b`](https://github.com/NixOS/nixpkgs/commit/69e85c1bf91d25c783cdbfa602139950074871e9) | `go-migrate: add meta.mainProgram`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136810">#136810</a></li></ul> |
| [`8c60eaa6`](https://github.com/NixOS/nixpkgs/commit/8c60eaa66a7b2bde36d39e1f295219162947ba25) | `gocryptfs: build documentation on aarch64-darwin again`                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136805">#136805</a></li></ul> |
| [`afcb5de6`](https://github.com/NixOS/nixpkgs/commit/afcb5de64dd04ffb26fe4f66f9978e5ec3acf2f6) | `haskellPackages.monadeli: update maintainer list to include ncfavier`                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`a3bc86ab`](https://github.com/NixOS/nixpkgs/commit/a3bc86aba30377b623cb398a78b6cb21e5cb880b) | `haskell.packages.ghc921.base-compat: use 0.12.0 for GHC 9.2 support`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`21e3afc6`](https://github.com/NixOS/nixpkgs/commit/21e3afc6a234a36bc91f6ed1609366095e4751fb) | `haskell-ci: make sure all dependencies use Cabal 3.4`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`9380d846`](https://github.com/NixOS/nixpkgs/commit/9380d8464bcb6f577709cfa6413d13c0b7a72691) | `haskellPackages.lambdabot-social-plugins,lambdabot: unbreak, add myself as maintainer` | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136797">#136797</a></li></ul> |
| [`ba1ecbea`](https://github.com/NixOS/nixpkgs/commit/ba1ecbea398cd28341c422f3a15e09a54fecfbd9) | `gnome.gnome-boxes: add qemu to path`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136789">#136789</a></li></ul> |
| [`6b93b667`](https://github.com/NixOS/nixpkgs/commit/6b93b667b24c5e65b63e42bec077102b3d94af44) | `haskellPackages.hakyll: Remove obsolete overrides`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`e4cbd7d9`](https://github.com/NixOS/nixpkgs/commit/e4cbd7d9b5a0153d21f3055c2d754b0eb06e9255) | `cabextract: support cross-compilation`                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136774">#136774</a></li></ul> |
| [`780956e7`](https://github.com/NixOS/nixpkgs/commit/780956e7cf9545c334da188501b99f9d0f8fe75f) | `sysklogd: support cross-compilation`                                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136771">#136771</a></li></ul> |
| [`9829823a`](https://github.com/NixOS/nixpkgs/commit/9829823acb1871f9f49ec2ad5180a42f9efd880f) | `xlockmore: 5.66 -> 5.67`                                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136747">#136747</a></li></ul> |
| [`6a57a78e`](https://github.com/NixOS/nixpkgs/commit/6a57a78ec0b696a5382f9c91397d397f9efc574e) | `worker: 4.8.1 -> 4.9.0`                                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136746">#136746</a></li></ul> |
| [`bf95b9a7`](https://github.com/NixOS/nixpkgs/commit/bf95b9a77053ec40b190759833e52bc5ba0d805d) | `xdotool: 3.20210804.2 -> 3.20210903.1`                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136743">#136743</a></li></ul> |
| [`72dfd9f6`](https://github.com/NixOS/nixpkgs/commit/72dfd9f635c1d1f702e05445865f076ca3d0565b) | `xst: small cosmetic rewrite`                                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136744">#136744</a></li></ul> |
| [`d26f8c44`](https://github.com/NixOS/nixpkgs/commit/d26f8c444f868278b1dfe764daa049b40a986694) | `st: small cosmetic rewrite`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136744">#136744</a></li></ul> |
| [`ff8d7d7d`](https://github.com/NixOS/nixpkgs/commit/ff8d7d7d3c39e6ac958c9039409485a862acb478) | `Pin reflex-dom-pandoc version`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`513a3ae3`](https://github.com/NixOS/nixpkgs/commit/513a3ae36c593ebba8a44bbe1e312d7611a12b00) | `step-ca: re-enable tests on darwin by enabling local networking`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136722">#136722</a></li></ul> |
| [`ac656b29`](https://github.com/NixOS/nixpkgs/commit/ac656b29083f779d653f00677b1f3b484917736d) | `haskellPackages.cabal-install-parsers: build with Cabal >= 3.6`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`796d31ab`](https://github.com/NixOS/nixpkgs/commit/796d31ab2210a4a19ae32cbd1d2e4c21480681cd) | `haskellPackages.distribution-nixpkgs: drop now unnecessary override`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`795e0d4c`](https://github.com/NixOS/nixpkgs/commit/795e0d4c6ea023997dd94ae46ffa96a10057bc06) | `haskellPackages: regenerate package set based on current config`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`73be7eaf`](https://github.com/NixOS/nixpkgs/commit/73be7eaf6401a3419b32429236158398d675a108) | `all-cabal-hashes: 2021-08-23T13:50:03Z -> 2021-09-03T13:28:39Z`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`72f0557f`](https://github.com/NixOS/nixpkgs/commit/72f0557fc4e81934335b34494983f2a31f74f179) | `haskellPackages: stackage-lts 18.7 -> 18.8`                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136589">#136589</a></li></ul> |
| [`151f3b03`](https://github.com/NixOS/nixpkgs/commit/151f3b03e56e6359c2ad2cb7fb52dd7fa24288f7) | `nextcloud-client: 3.3.2 -> 3.3.3`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136583">#136583</a></li></ul> |
| [`e6f94dea`](https://github.com/NixOS/nixpkgs/commit/e6f94dea3ea3df9d84c6c1870779b8867ab16290) | `vtk_7: Fix enableQt build`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136394">#136394</a></li></ul> |
| [`e6caf52f`](https://github.com/NixOS/nixpkgs/commit/e6caf52f64d5a6347913a0d75c68edf63a66a302) | `vtk_9: do not vendor libpng and libtiff`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136394">#136394</a></li></ul> |
| [`791f39c6`](https://github.com/NixOS/nixpkgs/commit/791f39c668e7f73077d52539061be39f24ceead0) | `haskell.compiler.*: clean up maintainer sets`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136376">#136376</a></li></ul> |
| [`c82ceee2`](https://github.com/NixOS/nixpkgs/commit/c82ceee2edce72419959eaf1b980f12251ed008c) | `vtk_9: fix Qt support`                                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136394">#136394</a></li></ul> |
| [`59d7d726`](https://github.com/NixOS/nixpkgs/commit/59d7d726f11b8c759ab1b804fa71c15cc1b25627) | `nixos/gnunet: improve service configuration`                                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/134070">#134070</a></li></ul> |
| [`2c603aef`](https://github.com/NixOS/nixpkgs/commit/2c603aef1b52baf3b87ad27301da1a8c39c36f96) | `flyctl: 0.0.232 -> 0.0.233`                                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135148">#135148</a></li></ul> |
| [`d88c26b4`](https://github.com/NixOS/nixpkgs/commit/d88c26b413a3b13c78b83a642d2c551900b5123f) | `fluxctl: 1.23.2 -> 1.24.0`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135146">#135146</a></li></ul> |
| [`21cdf18d`](https://github.com/NixOS/nixpkgs/commit/21cdf18de97ff61fad28baac5897fed531cdb944) | `drone-cli: 1.3.0 -> 1.3.1`                                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/135128">#135128</a></li></ul> |
| [`0d8df51c`](https://github.com/NixOS/nixpkgs/commit/0d8df51c23fa29584a4618fefd9ba5c5c546c034) | `tpm2-tss: fix support for abrmd`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/133395">#133395</a></li></ul> |
| [`7baf1801`](https://github.com/NixOS/nixpkgs/commit/7baf180128a8422629b5178354ffd5961afd3702) | `codeowners: Add Nixpkgs Markdown docs tooling`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130047">#130047</a></li></ul> |
| [`da95ab11`](https://github.com/NixOS/nixpkgs/commit/da95ab11b41eec733dca5212ce16d16a15dc55d4) | `doc: Add helper for converting DocBook files to Markdown`                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130047">#130047</a></li></ul> |
| [`04b59b03`](https://github.com/NixOS/nixpkgs/commit/04b59b0328daaa2e11f5e387ad3ec475cf2d2028) | `doc: Linkify man page references`                                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130047">#130047</a></li></ul> |
| [`c9139dfa`](https://github.com/NixOS/nixpkgs/commit/c9139dfa1a001e32baa6fea9c9373d80c83e39e9) | `doc: Add support for MyST roles`                                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130047">#130047</a></li></ul> |
| [`df55fbb6`](https://github.com/NixOS/nixpkgs/commit/df55fbb62aea05fa3e48c4f7c2021bba49485ed5) | `doc: comment lua scripts`                                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130047">#130047</a></li></ul> |
| [`a49d36b9`](https://github.com/NixOS/nixpkgs/commit/a49d36b979104205d016bb67d5ad6391df43e9ed) | `doc: Move lua filters to subdirectory`                                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/130047">#130047</a></li></ul> |
| [`45a5a681`](https://github.com/NixOS/nixpkgs/commit/45a5a6815c90cddd21b358a6bd314f777b01821f) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128878">#128878</a></li></ul> |
| [`69bf2d1e`](https://github.com/NixOS/nixpkgs/commit/69bf2d1ed5e4d933cc395a5a25d2b5181d26ffd6) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`a3480a0e`](https://github.com/NixOS/nixpkgs/commit/a3480a0e6959f69bdbafe31c4cce2c731a929934) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129154">#129154</a></li></ul> |
| [`ef37170c`](https://github.com/NixOS/nixpkgs/commit/ef37170c6dee5ce3c98126e12d09541fdf1e82ea) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128885">#128885</a></li></ul> |
| [`b69b26c1`](https://github.com/NixOS/nixpkgs/commit/b69b26c1a11ec79c2a5b5c6a189f54deda5f4673) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`227811ac`](https://github.com/NixOS/nixpkgs/commit/227811ac97db3e1b158a91815d0c521e4f56ae20) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128760">#128760</a></li></ul> |
| [`2d466c7a`](https://github.com/NixOS/nixpkgs/commit/2d466c7adc2daa950290467f245b2d24a36231f6) | `nixos: improve indentation in nixos/doc/manual/configuration/gpu-accel.chapter.md`     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`ad393d5f`](https://github.com/NixOS/nixpkgs/commit/ad393d5f63ebbf52b9c3977041910632ea30699c) | `nixos: use only URI fragment in manual options links`                                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`f6911a02`](https://github.com/NixOS/nixpkgs/commit/f6911a020e7e7be42d9d4f71baf5eb856efd0757) | `nixos: nixos/doc/manual/installation/upgrading.xml to CommonMark`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129154">#129154</a></li></ul> |
| [`b8540336`](https://github.com/NixOS/nixpkgs/commit/b85403368f4a27416961a443bf39fd41871c55c9) | `nixos: nixos/doc/manual/installation/changing-config.xml to CommonMark`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129154">#129154</a></li></ul> |
| [`e7c482f7`](https://github.com/NixOS/nixpkgs/commit/e7c482f78974407d0a110959ef4bc89a4bcc2e50) | `nixos: nixos/doc/manual/installation/obtaining.xml to CommonMark`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129154">#129154</a></li></ul> |
| [`9f7f6d22`](https://github.com/NixOS/nixpkgs/commit/9f7f6d225672bf05e714498dc6eaa68bd0800b69) | `nixos: nixos/doc/manual/administration typo fix`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`165d6bd2`](https://github.com/NixOS/nixpkgs/commit/165d6bd20c478c8c4f201c26eaa4c62e3c1b87ce) | `nixos: nixos/doc/manual/development/settings-options.xml to CommonMark`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`31be0b92`](https://github.com/NixOS/nixpkgs/commit/31be0b922d921fee8b7f81d8de2fb9f0c9ccbc3d) | `nixos: nixos/doc/manual/development/freeform-modules.xml to CommonMark`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`a743c6d3`](https://github.com/NixOS/nixpkgs/commit/a743c6d35a8e59aa8d0d92494c8e00a525a384f8) | `nixos: nixos/doc/manual/development/replace-modules.xml to CommonMark`                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`9afb04f7`](https://github.com/NixOS/nixpkgs/commit/9afb04f765bba1015314efb723a58ed68c393021) | `nixos: nixos/doc/manual/development/importing-modules.xml to CommonMark`               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`c0853101`](https://github.com/NixOS/nixpkgs/commit/c0853101833136590811a8c3cf30a989dd40a586) | `nixos: nixos/doc/manual/development/meta-attributes.xml to CommonMark`                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`d48cfce2`](https://github.com/NixOS/nixpkgs/commit/d48cfce2bf295ef125c94c41b6edacc284e06529) | `nixos: nixos/doc/manual/development/option-def.xml to CommonMark`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`bfd21cd2`](https://github.com/NixOS/nixpkgs/commit/bfd21cd2c1492b799facdab2e77308c34edbe9e7) | `nixos: nixos/doc/manual/development/option-types.xml to CommonMark`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`68770121`](https://github.com/NixOS/nixpkgs/commit/6877012179ebfbbf47451d2bc8d61212981c7940) | `nixos: nixos/doc/manual/development/option-declarations.xml to CommonMark`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129136">#129136</a></li></ul> |
| [`f8bdee00`](https://github.com/NixOS/nixpkgs/commit/f8bdee0054668f1ac7b30679e5ce6f5b95f160ee) | `nixos: nixos/doc/manual/configuration/kubernetes.xml to CommonMark`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`ee807a30`](https://github.com/NixOS/nixpkgs/commit/ee807a30cf093a0d16944350122cf5223c56629f) | `nixos: nixos/doc/manual/configuration/subversion.xml to CommonMark`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`747c6106`](https://github.com/NixOS/nixpkgs/commit/747c61066c5e204d4523177e7b49d143dfd4ed52) | `nixos: nixos/doc/manual/configuration/linux-kernel.xml to CommonMark`                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`35f476e8`](https://github.com/NixOS/nixpkgs/commit/35f476e8b99cfeca7660665763bfbd1fb179498a) | `nixos: nixos/doc/manual/configuration/xfce.xml to CommonMark`                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`5ad28f41`](https://github.com/NixOS/nixpkgs/commit/5ad28f419704436d1eaa0e82295f15c556fa5dce) | `nixos: nixos/doc/manual/configuration/gpu-accel.xml to CommonMark`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`f04b9023`](https://github.com/NixOS/nixpkgs/commit/f04b9023e36c290f41446240c55e1407ac8e0c9e) | `nixos: nixos/doc/manual/configuration/wayland.xml to CommonMark`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`36105633`](https://github.com/NixOS/nixpkgs/commit/361056334d9ceefb607c6f49068c2d4ead59a6cb) | `nixos: nixos/doc/manual/configuration/x-windows.xml to CommonMark`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`a55f0640`](https://github.com/NixOS/nixpkgs/commit/a55f0640b037a6d0771367622bd44996b8c74330) | `nixos: nixos/doc/manual/configuration/user-mgmt.xml to CommonMark`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129121">#129121</a></li></ul> |
| [`c603692b`](https://github.com/NixOS/nixpkgs/commit/c603692b0cfb096e9f8b861b7ce39978779a200a) | `nixos: nixos/doc/manual/administration/cleaning-store.xml to CommonMark`               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`e4ad7d6f`](https://github.com/NixOS/nixpkgs/commit/e4ad7d6fc7047ba322aea64a846f7781129aa508) | `nixos: nixos/doc/manual/administration/logging.xml to CommonMark`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`e63f5234`](https://github.com/NixOS/nixpkgs/commit/e63f523491e0bb757f66b91d5efb2d709612f4bd) | `nixos: nixos/doc/manual/administration/control-groups.xml to CommonMark`               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`8ee759d7`](https://github.com/NixOS/nixpkgs/commit/8ee759d7cf636e5f0747691874843fc52eb02296) | `nixos: nixos/doc/manual/administration/user-sessions.xml to CommonMark`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`adbe4e34`](https://github.com/NixOS/nixpkgs/commit/adbe4e34d61a1e6db49a4a4ffec236a1017d9507) | `nixos: nixos/doc/manual/administration/rebooting.xml to CommonMark`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`d37933c0`](https://github.com/NixOS/nixpkgs/commit/d37933c01f5bda5ed0d838d28d5e8180559ea953) | `nixos: nixos/doc/manual/administration/service-mgmt.xml to CommonMark`                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129083">#129083</a></li></ul> |
| [`1f3d5138`](https://github.com/NixOS/nixpkgs/commit/1f3d513839a5e721798d155fe4d1b3e5e613383e) | `nixos: nixos/doc/manual/development/writing-documentation.xml to CommonMark`           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129074">#129074</a></li></ul> |
| [`d80bde37`](https://github.com/NixOS/nixpkgs/commit/d80bde37a820767757a5ab33a83a7485822f5625) | `nixos: nixos/doc/manual/development/testing-installer.xml to CommonMark`               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129074">#129074</a></li></ul> |
| [`51bf2e17`](https://github.com/NixOS/nixpkgs/commit/51bf2e175ea8f511f6ed94ecb6c7cca3a873ccd7) | `nixos: nixos/doc/manual/development/building-parts.xml to CommonMark`                  | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129074">#129074</a></li></ul> |
| [`409934a6`](https://github.com/NixOS/nixpkgs/commit/409934a6e5f29ea9b9ac0ffc186b9a4772c4145a) | `nixos: nixos/doc/manual/development/sources.xml to CommonMark`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129074">#129074</a></li></ul> |
| [`445e922b`](https://github.com/NixOS/nixpkgs/commit/445e922b5bdc104b9797fc2bd58a243d3b942572) | `nixos: nixos/doc/manual/installation/installing-behind-a-proxy.xml to CommonMark`      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129003">#129003</a></li></ul> |
| [`060684ef`](https://github.com/NixOS/nixpkgs/commit/060684efa1485ee5745cd9077d8cd4953f3da0c5) | `nixos: nixos/doc/manual/installation/installing-from-other-distro.xml to CommonMark`   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129003">#129003</a></li></ul> |
| [`5a4d8ad8`](https://github.com/NixOS/nixpkgs/commit/5a4d8ad834e92d99b39de7e673fe26650cf3a175) | `nixos: nixos/doc/manual/installation/installing-virtualbox-guest.xml to CommonMark`    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129003">#129003</a></li></ul> |
| [`f6a42c13`](https://github.com/NixOS/nixpkgs/commit/f6a42c131ad6d2d0604d90deee86d371a639a43d) | `nixos: nixos/doc/manual/installation/installing-pxe.xml to CommonMark`                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129003">#129003</a></li></ul> |
| [`5f0e1822`](https://github.com/NixOS/nixpkgs/commit/5f0e1822e8533a266ef56607d305f657b98f58cd) | `nixos: nixos/doc/manual/installation/installing-usb.xml to CommonMark`                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/129003">#129003</a></li></ul> |
| [`9b52df30`](https://github.com/NixOS/nixpkgs/commit/9b52df304bb8e4f2ef0f00ad1cdabcc3243e7733) | `nixos: nixos/doc/manual/administration/container-networking.xml to CommonMark`         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128937">#128937</a></li></ul> |
| [`4f0efa8d`](https://github.com/NixOS/nixpkgs/commit/4f0efa8d7db269720192f6a4e3a2ffcbe35e30b3) | `nixos: nixos/doc/manual/administration/declarative-containers.xml to CommonMark`       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128937">#128937</a></li></ul> |
| [`0ac3e57a`](https://github.com/NixOS/nixpkgs/commit/0ac3e57ac1caa8249b966acda47ae3c08e5d31f1) | `nixos: nixos/doc/manual/administration/imperative-containers.xml to CommonMark`        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128937">#128937</a></li></ul> |
| [`828474ab`](https://github.com/NixOS/nixpkgs/commit/828474abfb4ccd324c1fce3da5f7b0ff454bb21e) | `nixos: nixos/doc/manual/administration/network-problems.xml to CommonMark`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128935">#128935</a></li></ul> |
| [`4df0b990`](https://github.com/NixOS/nixpkgs/commit/4df0b9903d391b7531e06ca859c46f261335bdc1) | `nixos: nixos/doc/manual/administration/store-corruption.xml to CommonMark`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128935">#128935</a></li></ul> |
| [`99493b61`](https://github.com/NixOS/nixpkgs/commit/99493b61ea5dc657a3febc6291bc83802005ad89) | `nixos: nixos/doc/manual/administration/rollback.xml to CommonMark`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128935">#128935</a></li></ul> |
| [`b5215f3f`](https://github.com/NixOS/nixpkgs/commit/b5215f3f73a7b4f6780c7215dade87513322cd5a) | `nixos: nixos/doc/manual/administration/maintenance-mode.xml to CommonMark`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128935">#128935</a></li></ul> |
| [`865b3918`](https://github.com/NixOS/nixpkgs/commit/865b3918f2a0853dfadc104394bbc98be114cf17) | `nixos: nixos/doc/manual/configuration/ad-hoc-packages.xml to CommonMark`               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128934">#128934</a></li></ul> |
| [`79134b77`](https://github.com/NixOS/nixpkgs/commit/79134b77aa823231b0fab75f0de366acb773ee19) | `nixos: nixos/doc/manual/configuration/luks-file-systems.xml to CommonMark`             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128933">#128933</a></li></ul> |
| [`0e7b4e60`](https://github.com/NixOS/nixpkgs/commit/0e7b4e60a846af1d4487ebe1218f8e07fffaa89b) | `Fix default pager environment`                                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128916">#128916</a></li></ul> |
| [`e6027717`](https://github.com/NixOS/nixpkgs/commit/e602771722d1820620f0e5cbecc821d561684a71) | `nixos: nixos/doc/manual/configuration/renaming-interfaces.xml to CommonMark`           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`55aa106c`](https://github.com/NixOS/nixpkgs/commit/55aa106c0b7fbb9f50b3bc791749fcb9822bb971) | `nixos: nixos/doc/manual/configuration/ad-hoc-network-config.xml to CommonMark`         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`54419f6e`](https://github.com/NixOS/nixpkgs/commit/54419f6e59c4fa0f39bc0cf367b7d690b9a4d40b) | `nixos: nixos/doc/manual/configuration/wireless.xml to CommonMark`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`97bfa927`](https://github.com/NixOS/nixpkgs/commit/97bfa927fae7362f8c11f70abe6f71dc7c31aa40) | `nixos: nixos/doc/manual/configuration/firewall.xml to CommonMark`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`dbd2d379`](https://github.com/NixOS/nixpkgs/commit/dbd2d379da8aafc41a2bdaff0a7226dd88527b9e) | `nixos: nixos/doc/manual/configuration/ipv6-config.xml to CommonMark`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`3d423e2b`](https://github.com/NixOS/nixpkgs/commit/3d423e2b1563ef4d38d0bb190935a26b58409b67) | `nixos: nixos/doc/manual/configuration/ipv4-config.xml to CommonMark`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`83fc29ff`](https://github.com/NixOS/nixpkgs/commit/83fc29ffb90742fb341a24aa27d2ad344b97a754) | `nixos: nixos/doc/manual/configuration/ssh.xml to CommonMark`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`c10ad530`](https://github.com/NixOS/nixpkgs/commit/c10ad53007d228f547026e31742ea7da46140824) | `nixos: nixos/doc/manual/configuration/network-manager.xml to CommonMark`               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128892">#128892</a></li></ul> |
| [`800c1f15`](https://github.com/NixOS/nixpkgs/commit/800c1f15a3ad3cbbce948d652b46406adeb2fc56) | `nixos: nixos/doc/manual/configuration/summary.xml to CommonMark`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128885">#128885</a></li></ul> |
| [`6122fb41`](https://github.com/NixOS/nixpkgs/commit/6122fb4123c98cbc39276c97d7d307dc82d32c58) | `nixos: nixos/doc/manual/configuration/modularity.xml to CommonMark`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128885">#128885</a></li></ul> |
| [`07ca0e23`](https://github.com/NixOS/nixpkgs/commit/07ca0e237ee479ff2b430989391179568b952864) | `nixos: nixos/doc/manual/configuration/config-file.xml to CommonMark`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128885">#128885</a></li></ul> |
| [`9f4535ff`](https://github.com/NixOS/nixpkgs/commit/9f4535ff162f55b2a3a3620de068352382dfcd58) | `nixos: nixos/doc/manual/configuration/customizing-packages.xml to CommonMark`          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128878">#128878</a></li></ul> |
| [`cba561d1`](https://github.com/NixOS/nixpkgs/commit/cba561d1a8b71d5bd9eb6d600feddfe106620eea) | `nixos: nixos/doc/manual/configuration/adding-custom-packages.xml to CommonMark`        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/128878">#128878</a></li></ul> |