### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10ce023e3d9c49111a05acb42930535b9d43097d",
-        "sha256": "1nja06dibv76md8b5rpz6mmydx2f4537dcflar6npg3x33s9qwcp",
+        "rev": "f96ba73ac0057f5da7920b9635b25938508ad39b",
+        "sha256": "1i7yd58843k2gpyl59flrlh09wr7877x8sda5rxfcm77lbxid05i",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/10ce023e3d9c49111a05acb42930535b9d43097d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f96ba73ac0057f5da7920b9635b25938508ad39b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      | Pull Requests                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`bbc51efb`](https://github.com/NixOS/nixpkgs/commit/bbc51efb464211fa141f142ae3b7a667b4f41ae2) | `nixos/grafana: systemd unit hardening`                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/134174">#134174</a></li></ul> |
| [`6513c6e8`](https://github.com/NixOS/nixpkgs/commit/6513c6e88e5501e79aeb9a4dddee9652a6a4cafe) | `htmlq: add nerdypepper as maintainer`                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137080">#137080</a></li></ul> |
| [`e32a7566`](https://github.com/NixOS/nixpkgs/commit/e32a7566d6980eb5d758e624eb486603d83f38e3) | `nodePackages: regenerate`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137015">#137015</a></li></ul> |
| [`6f419c3c`](https://github.com/NixOS/nixpkgs/commit/6f419c3cd8a36d833cf1ff144c2307031eb1706c) | `nodePackages.rust-analyzer: 0.2.727 -> 0.2.735`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137015">#137015</a></li></ul> |
| [`43152ffb`](https://github.com/NixOS/nixpkgs/commit/43152ffb579992dc6e0e55781436711f7bdfab1e) | `rust-analyzer: 2021-08-30 -> 2021-09-06`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137015">#137015</a></li></ul> |
| [`d559051a`](https://github.com/NixOS/nixpkgs/commit/d559051a1c578db37a8e85e132a07d8466b9cd37) | `zig: 0.8.0 -> 0.8.1`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136997">#136997</a></li></ul> |
| [`29d262cf`](https://github.com/NixOS/nixpkgs/commit/29d262cf7faae3370f45ce2eaff8f7f92f1a35ed) | `htmlq: init at 0.2.0`                                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137064">#137064</a></li></ul> |
| [`84bcbacc`](https://github.com/NixOS/nixpkgs/commit/84bcbaccd0c925e3e813e713605ae76308b6752b) | `maintainers: update vanilla's mail and add gpg key`                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137046">#137046</a></li></ul> |
| [`696ec0dc`](https://github.com/NixOS/nixpkgs/commit/696ec0dc6f9738c90a1db9b42115e60ada2df1df) | `python38Packages.dnachisel: 3.2.7 -> 3.2.8`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137062">#137062</a></li></ul> |
| [`172edcb4`](https://github.com/NixOS/nixpkgs/commit/172edcb4268a1cbd0a1eeb683ee4090367aa2c77) | `libspng: enable tests`                                             | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136274">#136274</a></li></ul> |
| [`7f084848`](https://github.com/NixOS/nixpkgs/commit/7f0848482049ad01a33d45e1d48e5f181fd3ed77) | `libspng: init at 0.7.0-rc3`                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136274">#136274</a></li></ul> |
| [`7caefdd0`](https://github.com/NixOS/nixpkgs/commit/7caefdd073266f4fb20c948f9fdf9c04f8d7aafb) | `luaformatter: fix darwin build`                                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136297">#136297</a></li></ul> |
| [`8bb040b3`](https://github.com/NixOS/nixpkgs/commit/8bb040b34cc10625103d986ba9a5cdb5a0f261f5) | `linux_5_13_hardened: Init`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137026">#137026</a></li></ul> |
| [`6a6ff4d0`](https://github.com/NixOS/nixpkgs/commit/6a6ff4d0d8d04d1e4fac847fdf78071838143847) | `linux_latest-libre: 18298 -> 18314`                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137026">#137026</a></li></ul> |
| [`785fa836`](https://github.com/NixOS/nixpkgs/commit/785fa836a105d64e9a0dd93b20240005b473b1fb) | `botan: mark as vulnerable to CVE-2021-40529`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137041">#137041</a></li></ul> |
| [`63bf10c8`](https://github.com/NixOS/nixpkgs/commit/63bf10c8487963d50d67024859178178f776164a) | `botan2: add patch for CVE-2021-40529`                              | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137041">#137041</a></li></ul> |
| [`c4b89f34`](https://github.com/NixOS/nixpkgs/commit/c4b89f347cf1d6f6813a34fa83bea94a850219f9) | `linode-cli: 5.8.1 -> 5.8.2`                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137040">#137040</a></li></ul> |
| [`509b969a`](https://github.com/NixOS/nixpkgs/commit/509b969a1804c5060bc9c34183b0752e1df4588a) | `botan2: 2.18.0 -> 2.18.1`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137041">#137041</a></li></ul> |
| [`9b4845fc`](https://github.com/NixOS/nixpkgs/commit/9b4845fcaf41fb48bff8eaa1badd1599c0fcfc20) | `docker-slim: 1.36.2 -> 1.36.4`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137052">#137052</a></li></ul> |
| [`be4bfef9`](https://github.com/NixOS/nixpkgs/commit/be4bfef913900114b18226464fa2278c72c6de6c) | `python39Packages.grpcio-tools: 1.39.0 -> 1.40.0`                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137055">#137055</a></li></ul> |
| [`8b5762af`](https://github.com/NixOS/nixpkgs/commit/8b5762afa94246701e97903f541b7bedf27dec34) | `postgresqlPackages.pgvector: 0.1.7 -> 0.1.8`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137053">#137053</a></li></ul> |
| [`f60eca11`](https://github.com/NixOS/nixpkgs/commit/f60eca11eff3966f2b39a1c6e8acd1a17cd48da7) | `nodejs-16_x: 16.8.0 -> 16.9.0`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137048">#137048</a></li></ul> |
| [`c00a8122`](https://github.com/NixOS/nixpkgs/commit/c00a8122522331e081e66604ed1cfd526882e691) | `syncthing: 1.18.1 -> 1.18.2`                                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137051">#137051</a></li></ul> |
| [`d7d170e7`](https://github.com/NixOS/nixpkgs/commit/d7d170e7c4e3e1f2e1b70e0ee01429c376e3de50) | `grpc: 1.39.1 -> 1.40.0`                                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137055">#137055</a></li></ul> |
| [`724809ea`](https://github.com/NixOS/nixpkgs/commit/724809eab9b9403848c8eed2582950e1dd70d7ef) | `ccloud-cli: 1.25 > 1.39 (#137016)`                                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137016">#137016</a></li></ul> |
| [`d72603b5`](https://github.com/NixOS/nixpkgs/commit/d72603b5eab34017b03150512712578757683243) | `home-assistant: pin aioesphomeapi to 7.0.0`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137030">#137030</a></li></ul> |
| [`a47005de`](https://github.com/NixOS/nixpkgs/commit/a47005debe819fc4fd83024e7be9c268788767a4) | `blackbox: only doCheck on x86_64-linux`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137027">#137027</a></li></ul> |
| [`3f2e194a`](https://github.com/NixOS/nixpkgs/commit/3f2e194a257e12cd77aed234138c5363f6c8116d) | `beetsExternalPlugins.extrafiles: fix mediafile dependency version` | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136955">#136955</a></li></ul> |
| [`1e75d0e2`](https://github.com/NixOS/nixpkgs/commit/1e75d0e22e070c9640dfaec1cfb17274673144e4) | `python3Packages.mediafile: 0.6.0 -> 0.8.0`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136955">#136955</a></li></ul> |
| [`63807721`](https://github.com/NixOS/nixpkgs/commit/6380772147db545f6de58e2c3d4e9b7363be6c05) | `python3Packages.pymazda: 0.2.0 -> 0.2.1`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136758">#136758</a></li></ul> |
| [`abfa8098`](https://github.com/NixOS/nixpkgs/commit/abfa8098ace1c87c6591cb27f9c1ac19d6081e9b) | `linux_5_13_hardened: 5.13.13 -> 5.13.14`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136944">#136944</a></li></ul> |
| [`1aba1d89`](https://github.com/NixOS/nixpkgs/commit/1aba1d891fbf3cf9a34c10b12f14f3dd64dba6f1) | `linux_5_10_hardened: 5.10.61 -> 5.10.62`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136944">#136944</a></li></ul> |
| [`8169d928`](https://github.com/NixOS/nixpkgs/commit/8169d9283ebd366a0effe99bd5d9f5caae3aebb3) | `linux_5_4_hardened: 5.4.143 -> 5.4.144`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136944">#136944</a></li></ul> |
| [`1c0e5d13`](https://github.com/NixOS/nixpkgs/commit/1c0e5d13a99b35f8587041064c7df57eef2e2fc8) | `linux_4_19_hardened: 4.19.205 -> 4.19.206`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136944">#136944</a></li></ul> |
| [`17681be1`](https://github.com/NixOS/nixpkgs/commit/17681be1d3d5dd86b33ce1e5178ed7e168a86dfc) | `linux_4_14_hardened: 4.14.245 -> 4.14.246`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136944">#136944</a></li></ul> |
| [`2d9b8a81`](https://github.com/NixOS/nixpkgs/commit/2d9b8a81e299d581330b81dd0aa571c802d72599) | `Add a comment to update script.`                                   | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136288">#136288</a></li></ul> |
| [`9215390c`](https://github.com/NixOS/nixpkgs/commit/9215390c882ae8c6d12694c575299e857e7b943f) | `python3Packages.angrop: 9.0.9684 -> 9.0.9792`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`e46e3c79`](https://github.com/NixOS/nixpkgs/commit/e46e3c798b8e2d456e41e5e8af3420ee516a51a1) | `python3Packages.angr: 9.0.9684 -> 9.0.9792`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`7d835af9`](https://github.com/NixOS/nixpkgs/commit/7d835af9d6f5cd7a7a78e1f940e2e63b210e95bb) | `python3Packages.cle: 9.0.9684 -> 9.0.9792`                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`a7cb4dab`](https://github.com/NixOS/nixpkgs/commit/a7cb4dabc70beaf675f172468bf4b2331b1473f3) | `python3Packages.claripy: 9.0.9684 -> 9.0.9792`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`2df513ae`](https://github.com/NixOS/nixpkgs/commit/2df513ae1a621c9f7e9b77b7a2fd11869a7158c3) | `python3Packages.pyvex: 9.0.9684 -> 9.0.9792`                       | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`6ba261ca`](https://github.com/NixOS/nixpkgs/commit/6ba261ca10031a7f6582273549db81740030b7e9) | `python3Packages.ailment: 9.0.9684 -> 9.0.9792`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`6439f26a`](https://github.com/NixOS/nixpkgs/commit/6439f26a9b6f95ad1717388a0d27541eeffa00e2) | `python3Packages.archinfo: 9.0.9684 -> 9.0.9792`                    | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137018">#137018</a></li></ul> |
| [`e70fac73`](https://github.com/NixOS/nixpkgs/commit/e70fac7374980c31b3346008f76405d04e1bc2f4) | `python38Packages.pubnub: 5.2.0 -> 5.2.1`                           | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137014">#137014</a></li></ul> |
| [`47aadbb2`](https://github.com/NixOS/nixpkgs/commit/47aadbb2377b220b4a0cb97faa50c68534e73437) | `vimPlugins.nvim-solarized-lua: init at 2021-07-09`                 | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136288">#136288</a></li></ul> |
| [`da8eac31`](https://github.com/NixOS/nixpkgs/commit/da8eac3184610dabfa6b80499f0d4f2b1af1548f) | `vimPlugins: update`                                                | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136288">#136288</a></li></ul> |
| [`9d0fb779`](https://github.com/NixOS/nixpkgs/commit/9d0fb7791ce4e77e4fa72687a631e0daf555f323) | `python38Packages.python-nomad: 1.3.0 -> 1.4.1`                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/137006">#137006</a></li></ul> |
| [`0a8efdb3`](https://github.com/NixOS/nixpkgs/commit/0a8efdb301acf6cbbaca20697bbdda2490e2bcd0) | `python38Packages.numpy-stl: 2.16.2 -> 2.16.3`                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136986">#136986</a></li></ul> |
| [`02b9630a`](https://github.com/NixOS/nixpkgs/commit/02b9630a70cd34ef72388de5eae48ce8da493951) | `gdu: 5.6.2 -> 5.7.0`                                               | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136984">#136984</a></li></ul> |
| [`f0aae718`](https://github.com/NixOS/nixpkgs/commit/f0aae71865fe753594257c2f0c8b0f891571500d) | `python38Packages.pyfma: 0.1.4 -> 0.1.6`                            | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136981">#136981</a></li></ul> |
| [`3280c76d`](https://github.com/NixOS/nixpkgs/commit/3280c76d56e2304b63dd208088ef111059a7132e) | `pythonPackages.karton-core: 4.2.0 -> 4.3.0`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136991">#136991</a></li></ul> |
| [`9966e067`](https://github.com/NixOS/nixpkgs/commit/9966e06770ed4d276757bd040cc5cb710690edaa) | `python3Packages.denonavr: 0.10.8 -> 0.10.9`                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136875">#136875</a></li></ul> |
| [`61d6e35a`](https://github.com/NixOS/nixpkgs/commit/61d6e35a39c6bba7311de26c771f76db49b8915e) | `etcher: 1.5.121 -> 1.5.122`                                        | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136856">#136856</a></li></ul> |
| [`f91cbe80`](https://github.com/NixOS/nixpkgs/commit/f91cbe80e4363726e5021e95c4b899030f3aea55) | `vouch-proxy: 0.32.0 -> 0.34.0`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136803">#136803</a></li></ul> |
| [`4991aade`](https://github.com/NixOS/nixpkgs/commit/4991aadefc9bee858ab9d49d5dbcc81c2b2ba6ed) | `mylvmbackup: init at 0.16`                                         | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136500">#136500</a></li></ul> |
| [`57c19d93`](https://github.com/NixOS/nixpkgs/commit/57c19d93dbdec18b16050b2d836014a650aeeb02) | `obs-studio: 27.0.0 -> 27.0.1`                                      | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136181">#136181</a></li></ul> |
| [`ed7e5ab3`](https://github.com/NixOS/nixpkgs/commit/ed7e5ab31c6b300dce5c1b6b9878ae8fd156709f) | `ipv6calc: 2.2.0 -> 3.2.0`                                          | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136168">#136168</a></li></ul> |
| [`d8835227`](https://github.com/NixOS/nixpkgs/commit/d88352270306803d03fb99c5daf32e0d1c7fed66) | `ip2location-c: 7.0.2 -> 8.4.0`                                     | <ul><li><a href="https://github.com/NixOS/nixpkgs/pull/136168">#136168</a></li></ul> |