### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a54d2e72e282f2bc68c49f82c735cf664244ec75",
-        "sha256": "0wvd7s75ilbi7c91sp850l8akfkx70jd0yk7hc2r0v3hcyzf8ldw",
+        "rev": "39b0c5ecc5f2991470e5fba4bd83935d88ee0016",
+        "sha256": "079f6adsk4qk40xicr8ibjncd74206aqyigpbb4xfgmkj7jm8ma8",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a54d2e72e282f2bc68c49f82c735cf664244ec75.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/39b0c5ecc5f2991470e5fba4bd83935d88ee0016.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`1ae90c51`](https://github.com/NixOS/nixpkgs/commit/1ae90c51183f3b7ac192018c17b696ef2ceedcb3) | `dhallPackages: Remove `dhall-packages` (#138487)`                                  |
| [`f0bc4d95`](https://github.com/NixOS/nixpkgs/commit/f0bc4d95b81e9b08fcdfbd96c5c6311190f2dbfe) | `pkgsStatic.toybox: fix build`                                                      |
| [`bdac6826`](https://github.com/NixOS/nixpkgs/commit/bdac6826b78c183ff2dd18e8db0b2825a60fd586) | `seatd: 0.5.0 -> 0.6.2`                                                             |
| [`b06ffb4b`](https://github.com/NixOS/nixpkgs/commit/b06ffb4b454286d71ad646fc7032942d2625f589) | `doc/rust: add missing fetchfromGitHub to derivation example`                       |
| [`73414b57`](https://github.com/NixOS/nixpkgs/commit/73414b570ad5a0e49fbe51236a3e0108710ef927) | `libdnf: switch back to default stdenv.`                                            |
| [`248eeddc`](https://github.com/NixOS/nixpkgs/commit/248eeddcddf680b5e92c5da149db1ce7e980a2c5) | `wget: 1.21.1 -> 1.21.2`                                                            |
| [`139c8fe7`](https://github.com/NixOS/nixpkgs/commit/139c8fe7055ee1788a3f2657525d41bf00cff6aa) | `elmPackages.*: auto upgrade`                                                       |
| [`cb916713`](https://github.com/NixOS/nixpkgs/commit/cb9167139eda6d4c3143d2ba1e7cf848a0a9718d) | `vmware-guest: Use vmware-vmblock-fuse for drag-and-drop synchronization (#131278)` |
| [`ca679942`](https://github.com/NixOS/nixpkgs/commit/ca67994224c253ac2c305392f8e58b3be78fea49) | `dua: 2.14.6 -> 2.14.7`                                                             |
| [`2448e9eb`](https://github.com/NixOS/nixpkgs/commit/2448e9eb11b313c3d30626e72c4aabba83cfd69e) | `python38Packages.scikit-hep-testdata: 0.4.7 -> 0.4.8`                              |
| [`3133899c`](https://github.com/NixOS/nixpkgs/commit/3133899cbc6a72d3a6282b46cbec465506fc2cd7) | `tailscale: 1.14.0 -> 1.14.3`                                                       |
| [`f8b837c8`](https://github.com/NixOS/nixpkgs/commit/f8b837c808490644bc7de35108a2212c22c8b262) | `ungoogled-chromium: 92.0.4515.159 -> 93.0.4577.82`                                 |
| [`0bdde7ec`](https://github.com/NixOS/nixpkgs/commit/0bdde7ecdf02f55d71792069c401fa270cf3e58c) | `haproxy: 2.3.13 -> 2.3.14`                                                         |
| [`4ec3a295`](https://github.com/NixOS/nixpkgs/commit/4ec3a29566d01b3a0ee80303a83d417c3de8ca33) | `maddy: remove maintainer (#138508)`                                                |
| [`defe183d`](https://github.com/NixOS/nixpkgs/commit/defe183dad2ab2b419314515326bdab93d35306a) | `firejail: Remove symlink check patch`                                              |
| [`64f5d681`](https://github.com/NixOS/nixpkgs/commit/64f5d681d95ba708afef378f86c5112798cc9039) | `nixos/physlock: fix broken wrapper`                                                |
| [`948ef8a6`](https://github.com/NixOS/nixpkgs/commit/948ef8a6c5fd2c71a5e45aecd5cc997740e91024) | `idris2: 0.4.0 -> 0.5.0`                                                            |
| [`2e44a72b`](https://github.com/NixOS/nixpkgs/commit/2e44a72b8f3cd35318af1b167994f78ca259e119) | `github-backup: 0.39.0 -> 0.40.0`                                                   |
| [`70a61f29`](https://github.com/NixOS/nixpkgs/commit/70a61f2921440a913e57d99f53fd5a7fbbe2e5dd) | `awscli2: 2.2.30 -> 2.2.39`                                                         |
| [`06a91dda`](https://github.com/NixOS/nixpkgs/commit/06a91dda9cae112c32177f64df4ebfc01be934e3) | `octoprint.python.pkgs.ender3v2tempfix: init at unstable-2021-04-27`                |
| [`e67bd161`](https://github.com/NixOS/nixpkgs/commit/e67bd161e0203b625fdf157b64dfd1730967a368) | `cicero-tui: 0.2.2 -> 0.3.0`                                                        |
| [`5ece1469`](https://github.com/NixOS/nixpkgs/commit/5ece1469136092a3509283c6d4942af2714fbca0) | `deltachat-desktop: 1.21.0 -> 1.21.1`                                               |
| [`4bb46590`](https://github.com/NixOS/nixpkgs/commit/4bb46590541798103eef60c7cbd3d1fb24e327eb) | `home-assistant: 2021.9.6 -> 2021.9.7`                                              |
| [`cba7d5d9`](https://github.com/NixOS/nixpkgs/commit/cba7d5d90e53094255b36816a04764a9803b4858) | `python3Packages.aioswitcher: 2.0.5 -> 2.0.6`                                       |
| [`f573a1b2`](https://github.com/NixOS/nixpkgs/commit/f573a1b2c435ee4e62edf9c24050e8674dfeafcf) | `python3Packages.plexapi: 4.7.0 -> 4.7.1`                                           |
| [`37cc6984`](https://github.com/NixOS/nixpkgs/commit/37cc698435f4546ba4ed7be972b1144bbc180816) | `python3Packages.pykodi: 0.2.5 -> 0.2.6`                                            |
| [`54bff886`](https://github.com/NixOS/nixpkgs/commit/54bff88644a6bfa52030d4356e07d4836b249201) | `python3Packages.PyChromecast: 9.2.0 -> 9.2.1`                                      |
| [`50010c72`](https://github.com/NixOS/nixpkgs/commit/50010c72c637f8442d30ba9a0702eded422bad00) | `python3Packages.pyopenuv: 2.2.0 -> 2.2.1`                                          |
| [`88b8df5c`](https://github.com/NixOS/nixpkgs/commit/88b8df5c21b7a081a58751466da5b1b248cae68d) | `linuxPackages.bcc: fix build`                                                      |
| [`9d529893`](https://github.com/NixOS/nixpkgs/commit/9d5298933afb1ed0dcada1eed9314e470458b7f8) | `zfs: add meta.mainProgram`                                                         |
| [`5ad7db7e`](https://github.com/NixOS/nixpkgs/commit/5ad7db7ed87e03e3fbd818f05f34010ebe9636db) | `openssh: add meta.mainProgram`                                                     |
| [`14791e1d`](https://github.com/NixOS/nixpkgs/commit/14791e1debe62e94fb2e8b8c8782b085c27f0d9a) | `gnugrep: add meta.mainProgram`                                                     |
| [`501cb25e`](https://github.com/NixOS/nixpkgs/commit/501cb25ed8c5dbf37dfd4c61365d5f18f12dc0ae) | `chia: 1.2.6 -> 1.2.7`                                                              |
| [`b6d51777`](https://github.com/NixOS/nixpkgs/commit/b6d517774cb41b6ba685223b6f7adf941b0ca26f) | `mnamer: 2.5.3 -> 2.5.4`                                                            |
| [`cb8b9f47`](https://github.com/NixOS/nixpkgs/commit/cb8b9f47f59ec6015a022eb332f147c2a904a59a) | `conftest: 0.27.0 -> 0.28.0`                                                        |
| [`13ccdc4e`](https://github.com/NixOS/nixpkgs/commit/13ccdc4e710c5a80a5b2a2ec704d0d796b0b8504) | `vendir: 0.22.0 -> 0.23.0`                                                          |
| [`bb198385`](https://github.com/NixOS/nixpkgs/commit/bb19838557dbd643b685ef395dc93632db59718f) | `tilt: 0.22.8 -> 0.22.9`                                                            |
| [`a0bbb9e7`](https://github.com/NixOS/nixpkgs/commit/a0bbb9e7667e10862e14056ae446a47b3c95aac7) | `zfsUnstable: correct sha256`                                                       |
| [`8ba5f811`](https://github.com/NixOS/nixpkgs/commit/8ba5f8115c6a21d98213f08716aae2f386443c26) | `nixos/zope2: define group`                                                         |
| [`23d14d89`](https://github.com/NixOS/nixpkgs/commit/23d14d89b8678944f8f8211f6366bba3d54f930c) | `nixos/tvheadend: define group, fix eval after #133166`                             |
| [`fd04a872`](https://github.com/NixOS/nixpkgs/commit/fd04a872bcc94c8eba9a34328d593e1d9d62f250) | `nixos/toxvpn: define group, fix eval after #133166`                                |
| [`d09ab775`](https://github.com/NixOS/nixpkgs/commit/d09ab77588852a9d30e7f85f85d5266f50f59f78) | `nixos/shout: define group, fix eval after #133166`                                 |
| [`feeca7dd`](https://github.com/NixOS/nixpkgs/commit/feeca7dd55f4e793487238311261ba45baf97684) | `nixos/rippled: define group, fix eval after #133166`                               |
| [`a654d779`](https://github.com/NixOS/nixpkgs/commit/a654d779fe57f8bcbf711353d2caa11423495506) | `nixos/ripple-data-api: define group`                                               |
| [`6cf8b27f`](https://github.com/NixOS/nixpkgs/commit/6cf8b27fd669eb19b63d4d25acc1b08460c0dd71) | `nixos/rdnssd: define group; fix after #133166`                                     |
| [`9ea37743`](https://github.com/NixOS/nixpkgs/commit/9ea377439ed377d61f9aad1df7e93ee3164beccd) | `thunderbird: 91.1.0 -> 91.1.1`                                                     |
| [`dd2d99ca`](https://github.com/NixOS/nixpkgs/commit/dd2d99cab705641876d3f76fb5ea01f9aa6abb0b) | `qv2ray: 2.6.3 -> 2.7.0`                                                            |
| [`4a978be0`](https://github.com/NixOS/nixpkgs/commit/4a978be0f16dc68cea959a0ad55de10b8e0dbd9c) | `thunderbird-bin: 91.1.0 -> 91.1.1`                                                 |
| [`94f77502`](https://github.com/NixOS/nixpkgs/commit/94f775024eec2cdf676ad1017a58660619fb3dd0) | `Opensnitch: Add module`                                                            |
| [`4c3d4d96`](https://github.com/NixOS/nixpkgs/commit/4c3d4d963b2e34829182e735c685ea14c9645e54) | `intensity-normalization: init at 2.0.1`                                            |
| [`2739ab54`](https://github.com/NixOS/nixpkgs/commit/2739ab54fbd496298a435a5d1aedfed80e0c56d6) | `python3Packages.scikit-fuzzy: unstable-2020-10-03 -> unstable-2021-03-31`          |
| [`7d8d6e8e`](https://github.com/NixOS/nixpkgs/commit/7d8d6e8e406c943a5fea1a803cc840380aa5ae19) | `cataclysm-dda: 0.F-1 -> 0.F-2`                                                     |