### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6b683c0527a7f777b5f2b4db2555891cd5a85f5",
-        "sha256": "0mkinbg2s4mg1ngh773h7rqc898siyigwy2wfz8jaai8k9srpx1n",
+        "rev": "bfc38d3d0d22c528e8abc46c5dd5f3f50fc4554b",
+        "sha256": "0hfxz9gnk6cjaa90halmw2334g6233izdw77li1jnv51m93miw57",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d6b683c0527a7f777b5f2b4db2555891cd5a85f5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/bfc38d3d0d22c528e8abc46c5dd5f3f50fc4554b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`8ef4b639`](https://github.com/NixOS/nixpkgs/commit/8ef4b6397f96934a8e0cbc9712ef85431d325f99) | `rust-script: init at 0.17.0`                                                  |
| [`9955eced`](https://github.com/NixOS/nixpkgs/commit/9955ecedec80099f29236341bb1d0fd678c6202a) | `python3Packages.plyer: init at 2.0.0 (#136902)`                               |
| [`89393893`](https://github.com/NixOS/nixpkgs/commit/89393893ec3ef669d06217ed98d54034118c5734) | `tauon: add optional withDiscordRPC (#138765)`                                 |
| [`c95fcfc6`](https://github.com/NixOS/nixpkgs/commit/c95fcfc6b3d2b02a2a8295d39460b05e4b0a221e) | `libfabric: meta.platforms = lib.platforms.all and 1.13.0 -> 1.13.1 (#138780)` |
| [`13bb5bc9`](https://github.com/NixOS/nixpkgs/commit/13bb5bc9473fc313f4ecb6d1bf3a1e841c45a90e) | `weechatScripts.edit: init at 1.0.2 (#135786)`                                 |
| [`016f9cf6`](https://github.com/NixOS/nixpkgs/commit/016f9cf6b52030da3385e87df00e3057dfbaed55) | `cargo-supply-chain: init at 0.0.2`                                            |
| [`4617dfb9`](https://github.com/NixOS/nixpkgs/commit/4617dfb92e79bfee380c40c3c2786824cd677460) | `EmptyEpsilon: use updated CMake target for GLM`                               |
| [`3de40cfe`](https://github.com/NixOS/nixpkgs/commit/3de40cfefc917649c176a050c7ecb2ddb371d844) | `exploitdb: 2021-09-18 -> 2021-09-21`                                          |
| [`14fbded6`](https://github.com/NixOS/nixpkgs/commit/14fbded6806f34c3d58a648dfe4e5ba880b0f4a6) | `roon-server: 1.8-814 -> 1.8-831`                                              |
| [`8fdbd06c`](https://github.com/NixOS/nixpkgs/commit/8fdbd06c51a9518fedc94a9b9a33772e88ea2a63) | `python3Packages.imap-tools: 0.47.0 -> 0.48.1`                                 |
| [`63ce41c0`](https://github.com/NixOS/nixpkgs/commit/63ce41c054876c0555553569237b035ebc65b65c) | `rust-analyzer: 2021-09-06 -> 2021-09-20`                                      |
| [`c426b46a`](https://github.com/NixOS/nixpkgs/commit/c426b46aeeca9965d5c4ef44824ad8ff3f78d22e) | `defaultCrateOverrides: add rdkafka-sys`                                       |
| [`f49be866`](https://github.com/NixOS/nixpkgs/commit/f49be866a94c73e15252c4967023b18076a66ff3) | `python3Packages.python3-gnutls: init at 3.1.9`                                |
| [`fde5e308`](https://github.com/NixOS/nixpkgs/commit/fde5e30809678760b74b990233e93368c2bb7a8c) | `starship: 0.57.0 -> 0.58.0`                                                   |
| [`def828ba`](https://github.com/NixOS/nixpkgs/commit/def828bab67e682c14a6b4f59beb9a133fbc54ea) | `bitmask-vpn: init at 0.21.6`                                                  |
| [`e4baf449`](https://github.com/NixOS/nixpkgs/commit/e4baf4492212f4268c31223ea91d43a1dfeeb405) | `blender: darwin add Applications and bin symlinks`                            |
| [`02323991`](https://github.com/NixOS/nixpkgs/commit/023239912cb60ffa5d8754ccaa867f2b0bce5c0a) | `nixos/mastodon: Add configurable web- and streaming concurrency`              |
| [`8c1e6a85`](https://github.com/NixOS/nixpkgs/commit/8c1e6a8598a34107d27444219778f55b1ba45ff4) | `nixos/mastodon: Fix sidekiq's DB_POOL, add configurable concurrency`          |
| [`6b960506`](https://github.com/NixOS/nixpkgs/commit/6b960506f789d649c6b5783688cac9345272f27c) | `pipe-viewer: init at 0.1.4`                                                   |
| [`99b632db`](https://github.com/NixOS/nixpkgs/commit/99b632dbf8af6a91cfb3e56dda46ad9317cc4804) | `perlPackages: fix same as perl licenses`                                      |
| [`8a54d527`](https://github.com/NixOS/nixpkgs/commit/8a54d527c7ade9f00c6fda8b021226dbaf49f610) | `perlPackages.TextParsewords: init at 3.30`                                    |
| [`58a963ac`](https://github.com/NixOS/nixpkgs/commit/58a963ac87e691790c4c0abbd61079585dd269cd) | `perlPackages.LWPUserAgentCached: init at 0.08`                                |
| [`ec3af76e`](https://github.com/NixOS/nixpkgs/commit/ec3af76e10c0e4ff6ff455be38b7a2b8bff58f55) | `nextcloud-client: 3.3.3 -> 3.3.4`                                             |
| [`d321f8ba`](https://github.com/NixOS/nixpkgs/commit/d321f8ba3904bc2fb4ca11317ac1fbc44cd74199) | `grafana: 8.1.4 -> 8.1.5`                                                      |
| [`a8fbb745`](https://github.com/NixOS/nixpkgs/commit/a8fbb745723062d99b64f34292f86e0ef4361921) | `matrix-synapse: 1.42.0 -> 1.43.0`                                             |
| [`8f8ac987`](https://github.com/NixOS/nixpkgs/commit/8f8ac987fb8839fb6c03b353f1c7dd2a63880885) | `hck: 0.6.4 -> 0.6.5`                                                          |
| [`065f6201`](https://github.com/NixOS/nixpkgs/commit/065f620184f30d4b332e8aaf76b7803d0eec68be) | `cargo-all-features: init at 1.6.0`                                            |
| [`8651143b`](https://github.com/NixOS/nixpkgs/commit/8651143b791b611ec185fcfed626dff085f7e032) | `Revert "Add packageTests"`                                                    |
| [`5e94e24b`](https://github.com/NixOS/nixpkgs/commit/5e94e24b14a4cfb02b7ca1ec3b0141c4a8a4b534) | `hors: fix darwin build`                                                       |
| [`7574cf28`](https://github.com/NixOS/nixpkgs/commit/7574cf28fefffa5b76dba22eb76e03dafd22aaca) | `matrix-synapse: enable parallel tests`                                        |
| [`896623db`](https://github.com/NixOS/nixpkgs/commit/896623dbe92e7b619badf22c5f5a0de2e338dc93) | `patchelf: fix homepage`                                                       |
| [`76a7ec23`](https://github.com/NixOS/nixpkgs/commit/76a7ec237ace2b3884a5fa3391dae0ce159626e8) | `cosign: 1.2.0 -> 1.2.1`                                                       |
| [`35b3dce8`](https://github.com/NixOS/nixpkgs/commit/35b3dce8f59326ea42dce77537b2a81d6cb9fa57) | `sysz: init at 1.3.0`                                                          |
| [`e8c3e05e`](https://github.com/NixOS/nixpkgs/commit/e8c3e05e11679adb11e331a47337d43c4c031514) | `cni-plugin-flannel: unstable-2021-09-10 -> 1.0`                               |
| [`6d3d8687`](https://github.com/NixOS/nixpkgs/commit/6d3d86870dfa85c2b9e87e87a7aea8ba37c95892) | `python3Packages.pytibber: 0.19.0 -> 0.19.1`                                   |
| [`df67b776`](https://github.com/NixOS/nixpkgs/commit/df67b776706cff7fac75cf4c2782c001444fa646) | `heisenbridge: 1.1.0 -> 1.1.1`                                                 |
| [`09dfbdf9`](https://github.com/NixOS/nixpkgs/commit/09dfbdf96ee852769da668cc60562cace1a5ed7c) | `Revert "anki-bin: force x11"`                                                 |
| [`c045c9b0`](https://github.com/NixOS/nixpkgs/commit/c045c9b0e74e507f8e6844060564ed00ab12897d) | `anki-bin: 2.1.47 -> 2.1.48`                                                   |
| [`e4809b11`](https://github.com/NixOS/nixpkgs/commit/e4809b114357f36a1734bf8a034c2fd148991ed9) | `linux_lqx: 5.13.15 -> 5.14.6`                                                 |
| [`33801181`](https://github.com/NixOS/nixpkgs/commit/338011815169868714409726ee2636d49f6d7282) | `julia-mono: 0.042 -> 0.043`                                                   |
| [`d954fd4c`](https://github.com/NixOS/nixpkgs/commit/d954fd4c3fa7c0f65432af57ed70882ba79d53a4) | `python3Packages.identify: 2.2.14 -> 2.2.15`                                   |
| [`ae5f12cc`](https://github.com/NixOS/nixpkgs/commit/ae5f12ccc33264bd177d575b950000320c1f43f9) | `nvidia_x11: 470.63.01 → 470.74`                                               |
| [`e10b10af`](https://github.com/NixOS/nixpkgs/commit/e10b10af399b9c4a187b9728f3dafa4ff0a81851) | `sic-image-cli: init at 0.19.0`                                                |
| [`28c2ee0b`](https://github.com/NixOS/nixpkgs/commit/28c2ee0bad8afd99155e2887322b3e06746e8122) | `hors: init at 0.8.2`                                                          |
| [`17b89a82`](https://github.com/NixOS/nixpkgs/commit/17b89a82df406bd943e2dc309aabeebe09372dc0) | `pipe-rename: init at 1.4.0`                                                   |
| [`7be344c9`](https://github.com/NixOS/nixpkgs/commit/7be344c926aaa977c89f00cc5d8a738d46aaf113) | `python3Packages.rapidfuzz: 1.6.0 -> 1.6.2`                                    |
| [`7e7a4021`](https://github.com/NixOS/nixpkgs/commit/7e7a4021e87fd18b575864ad1d539825d5e4787d) | `webkitgtk: 2.32.3 -> 2.32.4`                                                  |
| [`13a6e973`](https://github.com/NixOS/nixpkgs/commit/13a6e973339d97195a0c61aee6a71541d5ee5219) | `python3Packages.pyfronius: 0.6.3 -> 0.7.0`                                    |
| [`0e814601`](https://github.com/NixOS/nixpkgs/commit/0e814601e970b321269e2b897bcc97d3074f7a0f) | `python3Packages.apprise: 0.9.4 -> 0.9.5.1`                                    |
| [`37e257b3`](https://github.com/NixOS/nixpkgs/commit/37e257b3cdab995512ae819be89e4d951bcefc70) | `python3Packages.pyads: 3.3.7 -> 3.3.8`                                        |
| [`b8b772a1`](https://github.com/NixOS/nixpkgs/commit/b8b772a1da76d38e3c4446c875326fa939d815e1) | `linux/hardened/patches/5.14: 5.14.5-hardened1 -> 5.14.6-hardened1`            |
| [`a41022ed`](https://github.com/NixOS/nixpkgs/commit/a41022ed40d070bb23a365e4c3ee80618a3bb2cd) | `linux/hardened/patches/5.13: 5.13.18-hardened1 -> 5.13.19-hardened1`          |
| [`4a9ffb82`](https://github.com/NixOS/nixpkgs/commit/4a9ffb82aedee82a456268e402c714966adbbf2e) | `linux/hardened/patches/5.10: 5.10.66-hardened1 -> 5.10.67-hardened1`          |
| [`3e87ddbf`](https://github.com/NixOS/nixpkgs/commit/3e87ddbf57a85ca4f06f10f8579ed9c4a54768b0) | `linux-rt_5_10: 5.10.59-rt52 -> 5.10.65-rt53`                                  |
| [`51b0e449`](https://github.com/NixOS/nixpkgs/commit/51b0e44980a4939b21a6431d652169426840a335) | `linux: 5.14.5 -> 5.14.6`                                                      |
| [`748679c0`](https://github.com/NixOS/nixpkgs/commit/748679c0d3ab550ce8dbac4e5797e3b5d0064c76) | `linux: 5.13.18 -> 5.13.19`                                                    |
| [`66760dcb`](https://github.com/NixOS/nixpkgs/commit/66760dcbd5e30eb8950f79be847c052fe5de51f2) | `linux: 5.10.66 -> 5.10.67`                                                    |
| [`9ddee184`](https://github.com/NixOS/nixpkgs/commit/9ddee184059a009d494709c72e149d40acfcf1e5) | `python3Packages.httpcore: 0.13.6 -> 0.13.7`                                   |
| [`7af2448b`](https://github.com/NixOS/nixpkgs/commit/7af2448b6cc227ea85f6076e5b8ee0f517c66d42) | `chromiumBeta: 94.0.4606.50 -> 94.0.4606.54`                                   |
| [`fade6648`](https://github.com/NixOS/nixpkgs/commit/fade6648c75f7770578097aa09096e373d151231) | `nixos/localtimed: nogroup fix`                                                |
| [`1e7a9a68`](https://github.com/NixOS/nixpkgs/commit/1e7a9a68d6a43ea8c03e1f1fb06b17c03e719dfa) | `python3Packages.pontos: 21.7.4 -> 21.9.0`                                     |
| [`e5f70272`](https://github.com/NixOS/nixpkgs/commit/e5f70272c5ebe77cea9f045f8cac1d934d6a7ca5) | `gitlab: 14.2.3 -> 14.2.4`                                                     |
| [`695aaa9f`](https://github.com/NixOS/nixpkgs/commit/695aaa9f65f437ed57c79caaf467305c64a87309) | `python3Packages.pyvera: 0.3.13 -> 0.3.14`                                     |
| [`8c4d06ee`](https://github.com/NixOS/nixpkgs/commit/8c4d06ee0aa1438f6192e6c621a1bf0715085dee) | `wasm-pack: 0.9.1 -> 0.10.1`                                                   |
| [`ea71d92e`](https://github.com/NixOS/nixpkgs/commit/ea71d92e4e1055cd29536e9c1747712cd3fe4162) | `maintainers: add hleboulanger`                                                |
| [`5437b17b`](https://github.com/NixOS/nixpkgs/commit/5437b17b8ec41dbac81644744454836cae1ef0bf) | `nixos/malloc: add mimalloc`                                                   |
| [`eeea863e`](https://github.com/NixOS/nixpkgs/commit/eeea863edd189750190b6b66a5a414423ba5cb79) | `firefox: provide option to disable jemalloc`                                  |
| [`b23d8aa3`](https://github.com/NixOS/nixpkgs/commit/b23d8aa39cd2f49ec908d395adcbe7a70274ad9b) | `influxdb2: 2.0.6 -> 2.0.8`                                                    |
| [`0dd072f8`](https://github.com/NixOS/nixpkgs/commit/0dd072f89616e03cf54d65b12ad022aff4f10734) | `python3Packages.GitPython: 3.1.23 -> 3.1.24`                                  |
| [`6278ea9f`](https://github.com/NixOS/nixpkgs/commit/6278ea9fefc17da8c0ab3a69b2c0506475984527) | `python3Packages.plugwise: 0.13.1 -> 0.14.5`                                   |
| [`90003509`](https://github.com/NixOS/nixpkgs/commit/90003509941585339e9a1786446a36a0ce3fc149) | `nixos/smokeping: drop dangling fping6 suid swapper`                           |
| [`ac78ae80`](https://github.com/NixOS/nixpkgs/commit/ac78ae80a43c9ab27a434c3d1c62176cf93b5296) | `invalidateFetcherByDrvHash move docs to manual`                               |
| [`b502de64`](https://github.com/NixOS/nixpkgs/commit/b502de64766757b635ed2bb4aeb9532ceaefe71d) | `doc/builders/fetchers: Explain invalidateFetcherByDrvHash`                    |
| [`f74b1608`](https://github.com/NixOS/nixpkgs/commit/f74b1608328b31c554b8c34b1036cf6c02210004) | `doc/builders/fetchers: Document FOD caveats`                                  |
| [`c776833f`](https://github.com/NixOS/nixpkgs/commit/c776833f20673b8ea920fbc6173609a719415a42) | `kerbrute: init at 0.0.2`                                                      |
| [`3d83645f`](https://github.com/NixOS/nixpkgs/commit/3d83645ff502b0d0a619bb48bf0788468f38384a) | `apprise: 0.9.4 -> 0.9.5.1`                                                    |
| [`c76fbe82`](https://github.com/NixOS/nixpkgs/commit/c76fbe82b646df62cc3abd9925a01102bfe19128) | `grafana-image-renderer: 3.0.0 -> 3.2.0`                                       |
| [`7e1f162c`](https://github.com/NixOS/nixpkgs/commit/7e1f162c6ae3ff22624d60d7272838cf71e3dde6) | `pythonPackages.python-ironicclient: init 4.8.0`                               |
| [`c3c981d5`](https://github.com/NixOS/nixpkgs/commit/c3c981d590f2abef5736937f0aa5aa3c7d568fa3) | `pythonPackages.python-heatclient: init 2.4.0`                                 |
| [`0379ff19`](https://github.com/NixOS/nixpkgs/commit/0379ff190e3ac1419f47153a2d1127ca620a2912) | `pythonPackages.python-glanceclient: init 3.5.0`                               |
| [`823d8216`](https://github.com/NixOS/nixpkgs/commit/823d821679e45b6911f9ae61712df6fbac195a62) | `pythonPackages.python-manilaclient: init 3.0.0`                               |
| [`7e13a25c`](https://github.com/NixOS/nixpkgs/commit/7e13a25c8e23c5bd6229863d6239594b5210d1db) | `pythonPackages.tempest: init 28.1.0`                                          |
| [`7e4ea5c2`](https://github.com/NixOS/nixpkgs/commit/7e4ea5c265b4b428555013f6a3771f13d07d1183) | `pythonPackages.python-swiftclient: add pythonImportsCheck`                    |
| [`5e57188c`](https://github.com/NixOS/nixpkgs/commit/5e57188c65d94042eb55a8307c3f809235c2ffa0) | `pythonPackages.python-keystoneclient: 4.2.0 -> 4.3.0`                         |
| [`d74caf05`](https://github.com/NixOS/nixpkgs/commit/d74caf05a91edb6704f1f6e143d73433b4201cae) | `pythonPackages.keystoneauth1: 4.3.1 -> 4.4.0`                                 |
| [`947d4fc5`](https://github.com/NixOS/nixpkgs/commit/947d4fc5a6b09f1202f27824d8aa854a61cb1d38) | `pythonPackages.osc-lib: 2.4.1 -> 2.4.2`                                       |
| [`56b394aa`](https://github.com/NixOS/nixpkgs/commit/56b394aa2a0c71b09240c641f1c93dbfa4339993) | `pythonPackages.openstacksdk: add missing dependency; fix aarch64 tests`       |
| [`154b14b2`](https://github.com/NixOS/nixpkgs/commit/154b14b2f7744aac60a9a76f1f4a5cf02a17f1b3) | `python38Packages.trimesh: 3.9.29 -> 3.9.30`                                   |
| [`1b4a8a8c`](https://github.com/NixOS/nixpkgs/commit/1b4a8a8c184124f9d3a7a80089608d8b8f64b52c) | `mate.mate-screensaver: fix missing gsettings schema`                          |
| [`4738bfd5`](https://github.com/NixOS/nixpkgs/commit/4738bfd5635db216760321820b7d0848658a9eac) | `python3Packages.impacket: add missing dependency`                             |
| [`582e0a49`](https://github.com/NixOS/nixpkgs/commit/582e0a4926b435715cf4c2b339f458e8917c979f) | `tor-browser-bundle-bin: 10.5.5 -> 10.5.6`                                     |
| [`05e3b77a`](https://github.com/NixOS/nixpkgs/commit/05e3b77afc00b8f4eb71bb51df2511f6235edea8) | `puppet-bolt: init at 3.17.0`                                                  |
| [`52584637`](https://github.com/NixOS/nixpkgs/commit/525846372100f5c43a0fd27866995ab89d05fc2e) | `nixos/weylus: init`                                                           |
| [`87b3740d`](https://github.com/NixOS/nixpkgs/commit/87b3740d66b369e4e447f3fcb58a657a268f213d) | `Add packageTests`                                                             |
| [`0fa3d10d`](https://github.com/NixOS/nixpkgs/commit/0fa3d10d7d6f5ce0813ff6e2358150f5c8657378) | `fetchgit.tests: init`                                                         |
| [`6ea8d109`](https://github.com/NixOS/nixpkgs/commit/6ea8d10948a08cd776e51f70fdcc02024c02a9b4) | `invalidateFetcherByDrvHash: init`                                             |
| [`cf6f436a`](https://github.com/NixOS/nixpkgs/commit/cf6f436ae73afb3f2065982ab6e9184a7436b820) | `praat: 6.1.51 -> 6.1.52`                                                      |
| [`f859b895`](https://github.com/NixOS/nixpkgs/commit/f859b89525e7867f82a5c9310a479c5d4d14dd57) | `weylus: init at 0.11.2`                                                       |
| [`d4175e93`](https://github.com/NixOS/nixpkgs/commit/d4175e938058f0ffc9e1ee56197fac70a9229420) | `dolt: 0.27.4 -> 0.27.4.2`                                                     |
| [`6ed50f7d`](https://github.com/NixOS/nixpkgs/commit/6ed50f7dbf1e7fcd9ec74285de4b1cbdd5398c2f) | `vieb: Use 7za instead of 7z`                                                  |
| [`8da786e9`](https://github.com/NixOS/nixpkgs/commit/8da786e9f8fbdf97a22d3c16643e1f99221a3cfa) | `nixos: symlink to p7zip instead of using patchelf`                            |
| [`2a6c2b4a`](https://github.com/NixOS/nixpkgs/commit/2a6c2b4a1b2535fe06c5a6d4f46c3e941f0d0c61) | `vieb: fix internal node_modules structure`                                    |
| [`3e2fd659`](https://github.com/NixOS/nixpkgs/commit/3e2fd6595391975b097cdb9672e0acf256ac1bc8) | `vieb: Use autoPatchelfHook for 7z binary`                                     |
| [`22e52be3`](https://github.com/NixOS/nixpkgs/commit/22e52be3b35cb48d90ec76b6accdc243ee7c9714) | `nixos/apparmor: allow closure of selected mallocLib, fixes #125415`           |