### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d30701f2f17c18ca3096327dea5a6d09e26e8721",
-        "sha256": "1yr92z54rp8rkf29d6cp7kwc2gsf2dvfj1c1gr6yw95g37120gbs",
+        "rev": "37280c84c3eb31fa85b8a98046b3e471e5ddf09b",
+        "sha256": "1h1l63mn2isb87jw47007rpvhfvbrn6r1pkx89i7n2nlla3wh4iy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d30701f2f17c18ca3096327dea5a6d09e26e8721.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/37280c84c3eb31fa85b8a98046b3e471e5ddf09b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`6faa22c2`](https://github.com/NixOS/nixpkgs/commit/6faa22c229d61e5e515730a63af4e00f348f69c5) | `python38Packages.html5-parser: 0.4.9 -> 0.4.10`                              |
| [`f79dfb7b`](https://github.com/NixOS/nixpkgs/commit/f79dfb7bbb03167ab24f7af9e535b4ec2dcfcc2b) | `python38Packages.sentry-sdk: 1.3.1 -> 1.4.1`                                 |
| [`bc4060b2`](https://github.com/NixOS/nixpkgs/commit/bc4060b217bb2d99098f79d946ffbdc5f84f297d) | `python38Packages.sseclient-py: 1.7 -> 1.7.2`                                 |
| [`dbf552e9`](https://github.com/NixOS/nixpkgs/commit/dbf552e9f037b30fb137c0d795790bbff14ad750) | `python38Packages.transmission-rpc: 3.2.7 -> 3.2.8`                           |
| [`a154fc89`](https://github.com/NixOS/nixpkgs/commit/a154fc89831da60169ba9165930c96a855e23b39) | `python38Packages.pybullet: 3.1.8 -> 3.1.9`                                   |
| [`d60563ef`](https://github.com/NixOS/nixpkgs/commit/d60563ef676c8a87588fb9521462f710335c4451) | `python38Packages.zarr: 2.9.4 -> 2.10.0`                                      |
| [`cd7dedc4`](https://github.com/NixOS/nixpkgs/commit/cd7dedc4e7ad8bb49670818452f161ac51dbd145) | `python38Packages.sopel: 7.1.3 -> 7.1.4`                                      |
| [`ce0130d5`](https://github.com/NixOS/nixpkgs/commit/ce0130d58a9ff40f885066edb67c0a69873bf888) | `python38Packages.youtube-search-python: 1.4.7 -> 1.4.8`                      |
| [`922a904f`](https://github.com/NixOS/nixpkgs/commit/922a904ff6039a9805b597a244b0b9ba4c7a3d99) | `python38Packages.r2pipe: 1.6.0 -> 1.6.2`                                     |
| [`8c51fc6e`](https://github.com/NixOS/nixpkgs/commit/8c51fc6eee5ad3920424a9ae39955a4d9dc240b5) | `python38Packages.trimesh: 3.9.30 -> 3.9.31`                                  |
| [`4c056cf4`](https://github.com/NixOS/nixpkgs/commit/4c056cf4624228144bb877686a2e1dbeeff8c46d) | `python38Packages.mechanize: 0.4.6 -> 0.4.7`                                  |
| [`62207eec`](https://github.com/NixOS/nixpkgs/commit/62207eec010d76e69b1ba75eb7f72af0c223a9c8) | `zerotierone: 1.6.5 -> 1.6.6`                                                 |
| [`0669232a`](https://github.com/NixOS/nixpkgs/commit/0669232a9c16252c6f90eeeda72705837e727b3f) | `python38Packages.pytest-testmon: 1.1.2 -> 1.2.0`                             |
| [`cdee5d00`](https://github.com/NixOS/nixpkgs/commit/cdee5d000977eb20472b994d9694a6a196146fa1) | `python38Packages.tasklib: 2.3.0 -> 2.4.0`                                    |
| [`1fc8c4ea`](https://github.com/NixOS/nixpkgs/commit/1fc8c4ea839aa4367cf0d7526357f6a02be79380) | `python38Packages.python-hosts: 1.0.1 -> 1.0.2`                               |
| [`afc9fafd`](https://github.com/NixOS/nixpkgs/commit/afc9fafd463082463dd3cb8225b66ce4ab34753e) | `python38Packages.Pyro4: 4.80 -> 4.81`                                        |
| [`09076132`](https://github.com/NixOS/nixpkgs/commit/0907613236adfa4a86a52ecea884c0f829d2e64e) | `python38Packages.wadllib: 1.3.5 -> 1.3.6`                                    |
| [`31eca1b1`](https://github.com/NixOS/nixpkgs/commit/31eca1b1ead9b4334f8a692427d7266976f6476b) | `python38Packages.pysdl2: 0.9.8 -> 0.9.9`                                     |
| [`aae8f3d3`](https://github.com/NixOS/nixpkgs/commit/aae8f3d3901b72d8998266f37e912d58a68753c8) | `python3Packages.in-place: init at 0.5.0`                                     |
| [`89e4c181`](https://github.com/NixOS/nixpkgs/commit/89e4c181e58be38326b8e0a13a3dd5ba495ff477) | `python38Packages.azure-storage-file-share: 12.5.0 -> 12.6.0`                 |
| [`da84d9e7`](https://github.com/NixOS/nixpkgs/commit/da84d9e7195b80a13dea3dd785ee2f42802057e8) | `python38Packages.bids-validator: 1.8.2 -> 1.8.3`                             |
| [`63391899`](https://github.com/NixOS/nixpkgs/commit/63391899a35d732e85eb90efb8cf0c59d12f1c11) | `pythonPackages.Theano: fix cuda package`                                     |
| [`6ccb5fa3`](https://github.com/NixOS/nixpkgs/commit/6ccb5fa3e75244d22921734f4038e2865d11615d) | `python38Packages.iminuit: 2.8.2 -> 2.8.3`                                    |
| [`fa1860fe`](https://github.com/NixOS/nixpkgs/commit/fa1860fec43c5d8c7f243682eb46500f2186b40f) | `python38Packages.commoncode: 21.8.27 -> 21.8.31`                             |
| [`77bda46f`](https://github.com/NixOS/nixpkgs/commit/77bda46f1be6d9a87db187c8c57127910a5ef1cb) | `python38Packages.awscrt: 0.12.0 -> 0.12.2`                                   |
| [`7ade5fad`](https://github.com/NixOS/nixpkgs/commit/7ade5fad8f6af055dbdf09e6cd643b3ce0b5a690) | `python38Packages.mypy-boto3-s3: 1.18.29 -> 1.18.46`                          |
| [`1660b2f6`](https://github.com/NixOS/nixpkgs/commit/1660b2f6c2d4746d3399a3f48ca5ecb5c30dd074) | `open-policy-agent: 0.32.0 -> 0.32.1`                                         |
| [`40d7fc85`](https://github.com/NixOS/nixpkgs/commit/40d7fc853f32d102babc30f491a0f46cefa817cd) | `python38Packages.ibm-watson: 5.2.3 -> 5.3.0`                                 |
| [`cbc705bb`](https://github.com/NixOS/nixpkgs/commit/cbc705bb3d69bd696ef472bebd451f567ebe13a1) | `bashate: 2.0.0 -> 2.1.0`                                                     |
| [`d2349615`](https://github.com/NixOS/nixpkgs/commit/d2349615d9d611236102c1ee2be81bbc542d4ab4) | `metabigor: 1.9 -> 1.10`                                                      |
| [`b1ad7a53`](https://github.com/NixOS/nixpkgs/commit/b1ad7a530d148cd3ba4cb02b7ee13eed733109fc) | `kubesec: 2.11.3 -> 2.11.4`                                                   |
| [`281dd183`](https://github.com/NixOS/nixpkgs/commit/281dd1830d27faab2f806a0c7c75324ffe99747a) | `gleam: 0.16.1 -> 0.17.0`                                                     |
| [`7196b9b6`](https://github.com/NixOS/nixpkgs/commit/7196b9b61c33ac7ba6d0b0780ea0c79afeb6e0a0) | `esbuild: 0.12.28 -> 0.13.0`                                                  |
| [`143e73b2`](https://github.com/NixOS/nixpkgs/commit/143e73b2dee440fc2a5191c4b97fcd3b90e83524) | `kotlin: 1.5.30 -> 1.5.31`                                                    |
| [`77eb0d93`](https://github.com/NixOS/nixpkgs/commit/77eb0d932086c27267a21d484267fbde1b628f05) | `headscale: 0.7.1 -> 0.8.1`                                                   |
| [`a6005310`](https://github.com/NixOS/nixpkgs/commit/a6005310284fb1b5c76edd55f70e2a23fb0cfcd3) | `python38Packages.scrapy-deltafetch: 1.2.1 -> 2.0.1`                          |
| [`d32e0e6b`](https://github.com/NixOS/nixpkgs/commit/d32e0e6b1b6c308c28f954685cf63cf176db02af) | `llvmPackages_13.lld: add postPatch to fix Darwin build`                      |
| [`c1313e30`](https://github.com/NixOS/nixpkgs/commit/c1313e30fb12bec0e06a5460ef2a57e28707ea8f) | `htop: 3.0.5 -> 3.1.0`                                                        |
| [`24d13eb0`](https://github.com/NixOS/nixpkgs/commit/24d13eb04008ab80e3c0c012e9b6aa5d35397fc7) | `python3Packages.fpyutils: 2.0.0 -> 2.0.1`                                    |
| [`713ebe34`](https://github.com/NixOS/nixpkgs/commit/713ebe34dff6fa8bb0d27d1c76d5004183c73b66) | `python3Packages.casbin: add missing dependency`                              |
| [`e28643aa`](https://github.com/NixOS/nixpkgs/commit/e28643aa3d72b1380bf7d5a0d98745802f7374bc) | `conmon: 2.0.29 -> 2.0.30`                                                    |
| [`70ba7942`](https://github.com/NixOS/nixpkgs/commit/70ba7942665635af97fb161c910d9b24cad8174e) | `discord-canary: 0.0.130 -> 0.0.131`                                          |
| [`a343985a`](https://github.com/NixOS/nixpkgs/commit/a343985ac2b9a34ac8a76f0f6a15f78e5e86d7b8) | `discord-ptb: 0.0.25 -> 0.0.26`                                               |
| [`b23cf25c`](https://github.com/NixOS/nixpkgs/commit/b23cf25c51f04312fd6448711b15cc99aa5667bd) | `npiet: init at 1.3f`                                                         |
| [`6893c29f`](https://github.com/NixOS/nixpkgs/commit/6893c29faa3632c7188e4c20816a4ee601381e4b) | `kappanhang: init at 1.3`                                                     |
| [`b30b4dd5`](https://github.com/NixOS/nixpkgs/commit/b30b4dd510f96625d2d931d022f74a7e4652d581) | `maintainers: add mvs`                                                        |
| [`c36ec028`](https://github.com/NixOS/nixpkgs/commit/c36ec028c549445af7524d374ab152196de84d7b) | `deltachat-desktop: 1.21.1 -> 1.22.1`                                         |
| [`e78b3161`](https://github.com/NixOS/nixpkgs/commit/e78b3161d286fcf1a49ee939d9d942063a56a492) | `python3Packages.smbprotocol: 1.6.2 -> 1.7.0`                                 |
| [`e1fcd564`](https://github.com/NixOS/nixpkgs/commit/e1fcd5644ec9fdf3272e39b87a21b30fca9d73f7) | `python3Packages.types-requests: 2.25.6 -> 2.25.8`                            |
| [`340eef11`](https://github.com/NixOS/nixpkgs/commit/340eef1127c1841061b7fd0ea3700997e535dd09) | `fluxcd: add updateScript (#138776)`                                          |
| [`3cc8fbf6`](https://github.com/NixOS/nixpkgs/commit/3cc8fbf68f86c5453836115aecfaf6ec282abaa1) | `efm-langserver: 0.0.36 -> 0.0.37`                                            |
| [`3fac6d65`](https://github.com/NixOS/nixpkgs/commit/3fac6d6542f99d8b196b4719cc57246152d46546) | `fst: 0.4.5 -> 0.4.7`                                                         |
| [`0a192fa3`](https://github.com/NixOS/nixpkgs/commit/0a192fa3bcd4756db11f5b0d40e1683b4686744c) | `python3Packages.pyp: init at 0.3.4`                                          |
| [`eb1db6ee`](https://github.com/NixOS/nixpkgs/commit/eb1db6ee71508c0c9e51f36c025ac20a4dd669c4) | `python38Packages.azure-mgmt-containerinstance: 8.0.0 -> 9.0.0`               |
| [`5d6761be`](https://github.com/NixOS/nixpkgs/commit/5d6761be60e23caf72b72488576d6f9f4525cb94) | `kalker: use system gmp to fix aarch64-darwin`                                |
| [`91d925e8`](https://github.com/NixOS/nixpkgs/commit/91d925e85bbc5edf1d04ded77ea3545763f4cac7) | `grsync: 1.2.8 -> 1.3.0`                                                      |
| [`d52201bc`](https://github.com/NixOS/nixpkgs/commit/d52201bc4dc27da0a23da4e8e8b96e2be221eeea) | `python38Packages.aioesphomeapi: 9.1.0 -> 9.1.1`                              |
| [`3ba268b7`](https://github.com/NixOS/nixpkgs/commit/3ba268b73d41699edfaafb9a23052f291dfb9ac4) | `kstars: 3.5.4 -> 3.5.5`                                                      |
| [`dc032a86`](https://github.com/NixOS/nixpkgs/commit/dc032a866bbc68c219f0746f40f09679796cd296) | `libbfd: add libintl dependency for darwin.`                                  |
| [`11bf0ac2`](https://github.com/NixOS/nixpkgs/commit/11bf0ac25ba3a87f574f4b896646ebb2581edadf) | `pythonPackages.libgpuarray: fix opengl runpath`                              |
| [`ffc40e31`](https://github.com/NixOS/nixpkgs/commit/ffc40e31aca81c18da13ce7eefa464af62747f17) | `ursadb: switch to fetchFromGitHub`                                           |
| [`5d982374`](https://github.com/NixOS/nixpkgs/commit/5d982374d011dfa95d940d96e79a16022d032ec2) | `slimserver: switch to fetchFromGitHub`                                       |
| [`67764397`](https://github.com/NixOS/nixpkgs/commit/677643972fb428e709832d9be4afba364e367854) | `apacheHttpdPackages.mod_wsgi: switch to fetchFromGitHub`                     |
| [`c85679ef`](https://github.com/NixOS/nixpkgs/commit/c85679ef62f5071bf548759b190ea071684aaa6b) | `apacheHttpdPackages.mod_fastcgi: switch to fetchFromGitHub & mark as broken` |
| [`3c122940`](https://github.com/NixOS/nixpkgs/commit/3c12294098762298166a210558c781df092b9846) | `fcgiwrap: switch to fetchFromGitHub`                                         |
| [`d69406b8`](https://github.com/NixOS/nixpkgs/commit/d69406b88cfb6a21a69e376da0b5fb44f97ba4eb) | `couchpotato: switch to fetchFromGitHub`                                      |
| [`3d9480f7`](https://github.com/NixOS/nixpkgs/commit/3d9480f720d861d718487aa2c5fc9b6b8370a47a) | `beanstalkd: switch to fetchFromGitHub`                                       |
| [`63b1f69a`](https://github.com/NixOS/nixpkgs/commit/63b1f69a6deaf31596d57f78fcb4f521b1de9109) | `angelfish: 21.06 -> 21.08`                                                   |
| [`1c0d8b47`](https://github.com/NixOS/nixpkgs/commit/1c0d8b479803a3642a85f778017c0554d229d008) | `skytemple: 1.3.0 -> 1.3.1`                                                   |
| [`360ac489`](https://github.com/NixOS/nixpkgs/commit/360ac489b8706a9e8202e03856ca87d2f7706d01) | `python3Packages.skytemple-files: 1.3.0 -> 1.3.1`                             |
| [`b25f877b`](https://github.com/NixOS/nixpkgs/commit/b25f877b355d104daa19560c0df0bae3a8c7ecbc) | `osrm-backend: 5.25.0 -> 5.26.0`                                              |
| [`60218ef0`](https://github.com/NixOS/nixpkgs/commit/60218ef0bccae93d65c967a4edc7c1f4cbcc3d86) | `faraday-cli: init at 2.0.2`                                                  |
| [`2d5323d9`](https://github.com/NixOS/nixpkgs/commit/2d5323d99b37365331ced74cded6341f4c97dd20) | `python3Packages.env-canada: 0.5.12 -> 0.5.13`                                |
| [`a053f7d8`](https://github.com/NixOS/nixpkgs/commit/a053f7d84253b3f34db50e8b5bad33a55d809603) | `python3Packages.slack-sdk: 3.11.1 -> 3.11.2`                                 |
| [`787af490`](https://github.com/NixOS/nixpkgs/commit/787af490214e142ee836b959b560d12bd8a87272) | `python3Packages.simple-rest-client: init at 1.0.8`                           |
| [`7c04423e`](https://github.com/NixOS/nixpkgs/commit/7c04423e742f1ebdef67caecfcee1f666c90f7af) | `python3Packages.python-status: init at 1.0.1`                                |
| [`59ff8e13`](https://github.com/NixOS/nixpkgs/commit/59ff8e13b5741459ab8006eae567848d2a490047) | `python3Packages.faraday-plugins: init at 1.5.3`                              |
| [`57331741`](https://github.com/NixOS/nixpkgs/commit/573317418695d7d634e7d3f652bf9db3b3897589) | `gitlab-runner: 14.2.0 -> 14.3.0`                                             |
| [`3457a35d`](https://github.com/NixOS/nixpkgs/commit/3457a35dbbdfed4ce358a108fa47c3b13c790e36) | `flat-remix-gnome: 20210716 -> 20210921`                                      |
| [`bb89ef85`](https://github.com/NixOS/nixpkgs/commit/bb89ef8556a7d1674d79c8af1c69a828e46f1ec3) | `folly: 2021.09.13.00 -> 2021.09.20.00`                                       |
| [`12aa2201`](https://github.com/NixOS/nixpkgs/commit/12aa220159c78e0afe4a37b885a2b5f4b6f99143) | `discord-ptb,discord-canary: 0.0.25 -> 0.0.26, 0.0.130 -> 0.0.131`            |
| [`a6f47089`](https://github.com/NixOS/nixpkgs/commit/a6f470897c8470c83cfb58d9e2943d104d4dca07) | `cups-filters: 1.25.12 -> 1.28.10`                                            |
| [`e76363e3`](https://github.com/NixOS/nixpkgs/commit/e76363e33a35c6674c2312e2ae5c8dc1e8e1ccfd) | `python3Packages.requests-cache: 0.7.4 -> 0.8.1`                              |
| [`29c07c62`](https://github.com/NixOS/nixpkgs/commit/29c07c62d72a6d90b3ed2219de7c0338439198f4) | `linux_5_14: add hardened kernel`                                             |
| [`78c7f3c3`](https://github.com/NixOS/nixpkgs/commit/78c7f3c3db718da5ea13d8b6179976c7bbf99a2d) | `python38Packages.maxminddb: 2.0.3 -> 2.1.0`                                  |
| [`f73f35b8`](https://github.com/NixOS/nixpkgs/commit/f73f35b8c8967d851c3ef5da1862ed55aff448a1) | `fishnet: 2.2.6 -> 2.4.0, fix build`                                          |
| [`501cff7c`](https://github.com/NixOS/nixpkgs/commit/501cff7c32b2e664a74ca9e00073851cfa679a84) | `python3Packages.fastavro: init at 1.4.4`                                     |
| [`a790555b`](https://github.com/NixOS/nixpkgs/commit/a790555bee53818979e673dd04b3884c04be7da3) | `python38Packages.influxdb-client: 1.20.0 -> 1.21.0`                          |
| [`1e9bd432`](https://github.com/NixOS/nixpkgs/commit/1e9bd43214de0e1a5d1939c1cebffb16c85e2675) | `blast: 2.11.0 -> 2.12.0`                                                     |
| [`e951c821`](https://github.com/NixOS/nixpkgs/commit/e951c8214e88c3864df0bd52ff1e110f7571bdb1) | `python38Packages.django_3: 3.2.5 -> 3.2.7`                                   |
| [`a9bb7b02`](https://github.com/NixOS/nixpkgs/commit/a9bb7b02c99badc91a2fc48b1b87ad48c37b24ea) | `python3Packages.scikit-learn-extra: init at 0.2.0`                           |
| [`f84e6863`](https://github.com/NixOS/nixpkgs/commit/f84e68637df449a9160e1688141a148e4cd5d5ba) | `base16-shell-preview: 0.3.0 -> 1.0.0`                                        |
| [`4144492a`](https://github.com/NixOS/nixpkgs/commit/4144492aba46e1142de1282769b0c0d51ec6000f) | `upwork: 5.6.7.13 -> 5.6.8.0`                                                 |