### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "841b22ab76741eb4d2edcb48117a688e7d7f1b24",
-        "sha256": "1jqr2x8sphppm8n8r49wdhqqsdfq3cqa0hmr4rai6j08gqcxnq0a",
+        "rev": "e9540c5f121d77c68de0f2156cb6f9869d95a6f8",
+        "sha256": "0s0i6x78nxjyc0a885hzvwh5bylccixiam6c5h1q6pa64aqx50pc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/841b22ab76741eb4d2edcb48117a688e7d7f1b24.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9540c5f121d77c68de0f2156cb6f9869d95a6f8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`99b632b2`](https://github.com/NixOS/nixpkgs/commit/99b632b2208b69911f3ca48cc0f5fb095e2d2314) | `python38Packages.yt-dlp: 2021.9.2 -> 2021.9.25`                                            |
| [`e95a50a6`](https://github.com/NixOS/nixpkgs/commit/e95a50a64b4061ab2cb0572ac493f841e7b65b14) | `nixos/networkd: add ActivationPolicy option`                                               |
| [`780415ce`](https://github.com/NixOS/nixpkgs/commit/780415ce5d5bf3df6e361178206cd1185c56c4b9) | `cargo-llvm-lines: 0.4.11 -> 0.4.12`                                                        |
| [`de68426d`](https://github.com/NixOS/nixpkgs/commit/de68426db81f8061923b283118d5d7f6582b3c29) | `ocamlPackages.labltk: add version 8.06.11 for OCaml 4.13`                                  |
| [`5f7019ed`](https://github.com/NixOS/nixpkgs/commit/5f7019ed8a8ad8af7a4db18a12fe2fb8955a647a) | `prisma: 2.30.2 -> 3.1.1`                                                                   |
| [`0f9a1d70`](https://github.com/NixOS/nixpkgs/commit/0f9a1d70fad4af54a0d411b306427823476dcced) | `meilisearch: add docs`                                                                     |
| [`faef9593`](https://github.com/NixOS/nixpkgs/commit/faef95930b1b52b93d8c98cdf5032fdcbfb93a3f) | `meilisearch: add meta`                                                                     |
| [`847bfb3d`](https://github.com/NixOS/nixpkgs/commit/847bfb3df34b42daca5203c4828af57a46538d8f) | `tdesktop: 3.1.0 -> 3.1.1`                                                                  |
| [`8bc030eb`](https://github.com/NixOS/nixpkgs/commit/8bc030eb13ea2fd611e446042340e9f19aa218e4) | `llvmPackages_13: 13.0.0-rc3 -> 13.0.0-rc4`                                                 |
| [`3bc4a574`](https://github.com/NixOS/nixpkgs/commit/3bc4a574dbb1674cf99eda99bb4af364c9c8472a) | `prisma: add pimeys as maintainer`                                                          |
| [`47557e29`](https://github.com/NixOS/nixpkgs/commit/47557e2984cac84711bf3aad6213dade0907116f) | `nodesPackages.prisma: #135934 follow-up corrections`                                       |
| [`d047d336`](https://github.com/NixOS/nixpkgs/commit/d047d336d60433a07c8e0de2dee45cfad8ceecef) | `prisma-engines: #135934 follow-up corrections`                                             |
| [`88cdb0a3`](https://github.com/NixOS/nixpkgs/commit/88cdb0a3c041ab6a401c6776de548e72bb332e22) | `wifite2: add pixiewps dependency`                                                          |
| [`54051ba4`](https://github.com/NixOS/nixpkgs/commit/54051ba41855a1bbbe8ebe4d6f87386604fb6df9) | `comby: 1.5.1 -> 1.7.0`                                                                     |
| [`29efb76a`](https://github.com/NixOS/nixpkgs/commit/29efb76ab6480426ce8c1f7bd8e341f0249a61cc) | `google-chrome: add pipewire dependency`                                                    |
| [`2fb9f65c`](https://github.com/NixOS/nixpkgs/commit/2fb9f65c0a1c9d6624b5c0a237b3eaa9d14b8dcd) | `comby: nixpkgs-fmt`                                                                        |
| [`ccb5c228`](https://github.com/NixOS/nixpkgs/commit/ccb5c2285b2f8110ae469ac23e2cad63f761ed95) | `perlPackages.ConvertASN1: 0.27 -> 0.33`                                                    |
| [`d800b42d`](https://github.com/NixOS/nixpkgs/commit/d800b42dec422dcf09f908f2065ef310e5fb38b4) | `udunits: meta.platforms = lib.platforms.all`                                               |
| [`df02d2b1`](https://github.com/NixOS/nixpkgs/commit/df02d2b17570f569c50e9e5fd340697d0272cd8c) | `python38Packages.goalzero: 0.1.59 -> 0.2.0`                                                |
| [`29ba0603`](https://github.com/NixOS/nixpkgs/commit/29ba06034e1f9d17f260240a24020beb5ddddaad) | `python38Packages.fountains: 1.0.0 -> 1.1.0`                                                |
| [`54974715`](https://github.com/NixOS/nixpkgs/commit/5497471572f8a8c4e0ca1b44bfd4de854023b85d) | `python38Packages.deemix: 3.5.1 -> 3.5.3`                                                   |
| [`e456e9b1`](https://github.com/NixOS/nixpkgs/commit/e456e9b1ae467c8f83b923dbd2fea337dfe9ff3c) | `sigtool: 0.1.0 -> 0.1.2`                                                                   |
| [`28d8ad0b`](https://github.com/NixOS/nixpkgs/commit/28d8ad0be1a42ac439f4bfe84df1c1eac4c83506) | `firefox-bin: Don't reference gnome in expression`                                          |
| [`8eeb28ff`](https://github.com/NixOS/nixpkgs/commit/8eeb28ffc3cb5265d080626faa76c6e600c32d33) | `firefox-devedition-bin: 90.0b6 -> 93.0b9`                                                  |
| [`5a566e3e`](https://github.com/NixOS/nixpkgs/commit/5a566e3e7762bdc5ca5f6296f3d72e61dbd597ba) | `firefox-beta-bin: 90.0b6 -> 93.0b9`                                                        |
| [`aec24826`](https://github.com/NixOS/nixpkgs/commit/aec248263991541bebfb781376543d26d6c79d7f) | `supertag: fix build caused by outdated lexical-core`                                       |
| [`98fe3260`](https://github.com/NixOS/nixpkgs/commit/98fe3260c624d94726aec9ff7f7c4f2f456ceea1) | `nixos/gnome: Fix broken .gnome-shell-wrapped wrapper`                                      |
| [`b7d6c648`](https://github.com/NixOS/nixpkgs/commit/b7d6c64871a68f76979015b7434233d84370686e) | `gotestsum: fix package name in ldflags`                                                    |
| [`eba807d5`](https://github.com/NixOS/nixpkgs/commit/eba807d5949801334cf4742423e8a7d5eb161d26) | `chromiumDev: 95.0.4638.17 -> 96.0.4651.0`                                                  |
| [`a7943950`](https://github.com/NixOS/nixpkgs/commit/a79439501f2c40dde884f59b32ef0d5f8701b091) | `gdu: 5.8.0 -> 5.8.1`                                                                       |
| [`6c3324e2`](https://github.com/NixOS/nixpkgs/commit/6c3324e245a25d9f3417e2f5e7c9c01aadbf7127) | `coqPackages.flocq: 3.3.1 → 3.4.2`                                                          |
| [`d9ef3f10`](https://github.com/NixOS/nixpkgs/commit/d9ef3f10e9dcf4ad1cdd55c186c9ae25773446e4) | `watson: Install fish completions.`                                                         |
| [`1490399b`](https://github.com/NixOS/nixpkgs/commit/1490399beb4199a79a4a4b83a5bee974f1860f15) | `kanit-font: mirroring latest styling suggestions from chonburi-font`                       |
| [`59740c03`](https://github.com/NixOS/nixpkgs/commit/59740c03de7f6e3820f6f91e88175df2058b0689) | `chonburi-font: init at unstable-2021-09-15`                                                |
| [`37ec684a`](https://github.com/NixOS/nixpkgs/commit/37ec684a5c010aa7cf51abaf29691ef2333d6625) | `psi-notify: init at 1.2.1`                                                                 |
| [`f779a0ff`](https://github.com/NixOS/nixpkgs/commit/f779a0ff03497e83dab5b04182c13cd2ef347274) | `nix-output-monitor: 1.0.3.2 -> 1.0.3.3`                                                    |
| [`447e08c3`](https://github.com/NixOS/nixpkgs/commit/447e08c3dad83341f5c7473ab229e29f8aa129cc) | `sleuthkit: add build for JNI libraries`                                                    |
| [`3cfee020`](https://github.com/NixOS/nixpkgs/commit/3cfee020814ceaa8a5a5a5ba2de87efcae62c2db) | `pythonPackages.python-osc: init at 1.7.7`                                                  |
| [`868a8a52`](https://github.com/NixOS/nixpkgs/commit/868a8a5218542d352ef3abd743df92b291648544) | `python3Packages.aioapns: init 2.0.2`                                                       |
| [`7fdded5c`](https://github.com/NixOS/nixpkgs/commit/7fdded5cd04540832738d2d440d8e876bff3e982) | `nodePackages.browser-sync: init at 2.27.5`                                                 |
| [`25c840ed`](https://github.com/NixOS/nixpkgs/commit/25c840ed1bde9516670c591e31c4acdf660e9425) | `cloak: init at 0.2.0`                                                                      |
| [`7b6eb919`](https://github.com/NixOS/nixpkgs/commit/7b6eb919617de0b184618df9cbf2d108b01abd06) | `align: init at 1.1.3`                                                                      |
| [`b27698e0`](https://github.com/NixOS/nixpkgs/commit/b27698e075a2d8a9670adf51e98917a35f11392e) | `python3Packages.APScheduler: fix build`                                                    |
| [`c415f709`](https://github.com/NixOS/nixpkgs/commit/c415f70996c99be6cb916a70fc4dba2647933ea2) | `tv: 0.6.0 -> 0.7.0`                                                                        |
| [`15bb3ac5`](https://github.com/NixOS/nixpkgs/commit/15bb3ac5a92552e1264bb457084eea72b263e179) | `chromium: 94.0.4606.54 -> 94.0.4606.61`                                                    |
| [`5321c273`](https://github.com/NixOS/nixpkgs/commit/5321c273076a272e486e5b138d39ff5a1bec8d8c) | `zeek: 4.1.0 -> 4.1.1`                                                                      |
| [`afaf8d09`](https://github.com/NixOS/nixpkgs/commit/afaf8d094b98f8099cf29d789d33b122af6ad1ca) | `ungoogled-chromium: 93.0.4577.82 -> 94.0.4606.54`                                          |
| [`b9468515`](https://github.com/NixOS/nixpkgs/commit/b9468515932d827651838700969fc6b415590af0) | `chromiumBeta: 94.0.4606.54 -> 95.0.4638.17`                                                |
| [`c1d26607`](https://github.com/NixOS/nixpkgs/commit/c1d266076501052f2241c46e8e69d7169a02d888) | `Update pkgs/tools/audio/kaldi/default.nix`                                                 |
| [`10770653`](https://github.com/NixOS/nixpkgs/commit/10770653d783ace820726977433e23526bae31e7) | `sks: remove myself as maintainer`                                                          |
| [`61a7f5f9`](https://github.com/NixOS/nixpkgs/commit/61a7f5f90d93dda7cce27836295288cc0bd9a3f6) | `iproute_mptcp: Fix the build`                                                              |
| [`d49c3d09`](https://github.com/NixOS/nixpkgs/commit/d49c3d09bebeec287bb53c4cb020de299ed280f2) | `python38Packages.awscrt: 0.12.2 -> 0.12.3`                                                 |
| [`e36f885a`](https://github.com/NixOS/nixpkgs/commit/e36f885a098825a0228a7967b312873f08a6916e) | `rstudio: remove ehmry from maintainers`                                                    |
| [`25f627ea`](https://github.com/NixOS/nixpkgs/commit/25f627eaac5ae4a386b397cb56e5e572c53b2c4c) | `python38Packages.mypy-boto3-s3: 1.18.46 -> 1.18.47`                                        |
| [`bda03add`](https://github.com/NixOS/nixpkgs/commit/bda03add2bcd6ee6406daea4783000d26dcd0c56) | `python3Packages.fountains: 0.2.1 -> 1.0.0`                                                 |
| [`74890343`](https://github.com/NixOS/nixpkgs/commit/74890343e45aac498f881fa8a51e19a9456b5141) | `python3Packages.bitlist: 0.4.0 -> 0.5.1`                                                   |
| [`4f8b48e4`](https://github.com/NixOS/nixpkgs/commit/4f8b48e432d37b4bda1013ca99aab702e6138aac) | `texlive.bin.core: remove format -> engine links (#136293)`                                 |
| [`e1ce3b2e`](https://github.com/NixOS/nixpkgs/commit/e1ce3b2eecef512c4ea2311774fecae0ae63afc8) | `kaldi: fix build`                                                                          |
| [`39e8ec2d`](https://github.com/NixOS/nixpkgs/commit/39e8ec2db68b863543bd377e44fbe02f8d05864e) | `maintainers/scripts/rebuild-amount.sh: report parallelism, add example, cleanup (#137695)` |
| [`28260c12`](https://github.com/NixOS/nixpkgs/commit/28260c122d83205838429ce1f44e6992d98463cc) | `gokart: 0.2.0 -> 0.3.0`                                                                    |
| [`affa5e38`](https://github.com/NixOS/nixpkgs/commit/affa5e384f151cf79aa935397f4d56d64bf86f8f) | `python3Packages.pysyncobj: 0.3.8 -> 0.3.10`                                                |
| [`5b1ce387`](https://github.com/NixOS/nixpkgs/commit/5b1ce387db813d0378a6f9c4e096ebf280a01bcc) | `python3Packages.adjusttext: add doCheck`                                                   |
| [`2588a5f6`](https://github.com/NixOS/nixpkgs/commit/2588a5f650dfa43c30f81a5c00ed2cc396c65c9a) | `python3Packages.python-http-client: 3.3.2 -> 3.3.3`                                        |
| [`3a758199`](https://github.com/NixOS/nixpkgs/commit/3a75819912b12ad308a6a19cd9356c2553603505) | `Bump pytorch-bin to 1.9.1`                                                                 |
| [`48216e46`](https://github.com/NixOS/nixpkgs/commit/48216e46892917b05e9f2ee9033e0b0b5d3a6375) | `slack: 4.18.0 -> 4.19.x`                                                                   |
| [`e31a829e`](https://github.com/NixOS/nixpkgs/commit/e31a829e26d63cda34aaabe0fb6d6074cf05e58f) | `python38Packages.hvac: 0.11.0 -> 0.11.2`                                                   |
| [`dbb297ba`](https://github.com/NixOS/nixpkgs/commit/dbb297ba7a56cb784f98acfec5b0624deb6a9aa1) | `ryujinx: 1.0.6954 -> 1.0.7047`                                                             |
| [`e3f9cf25`](https://github.com/NixOS/nixpkgs/commit/e3f9cf25e126c1aeaec41994a08c5137be151636) | `python38Packages.youtube-search-python: 1.4.7 -> 1.4.8`                                    |
| [`bd0701bf`](https://github.com/NixOS/nixpkgs/commit/bd0701bf3d4684677d3d1875e00b2febfc4d9a0f) | `python38Packages.APScheduler: 3.7.0 -> 3.8.0`                                              |
| [`08b2a9c9`](https://github.com/NixOS/nixpkgs/commit/08b2a9c91f77ab7d58e9e301ee3e857fb8dd9362) | `maintainers: add anirrudh`                                                                 |
| [`d7bba45c`](https://github.com/NixOS/nixpkgs/commit/d7bba45c605304637d77269dfa5ddb0b30b96eee) | `python38Packages.simple-salesforce: 1.11.3 -> 1.11.4`                                      |
| [`dc7bf062`](https://github.com/NixOS/nixpkgs/commit/dc7bf06273869392f8a2c20cee8696eff4478b5c) | `python38Packages.robotframework-requests: 0.9.1 -> 0.9.2`                                  |
| [`ccfdf4e5`](https://github.com/NixOS/nixpkgs/commit/ccfdf4e538e8c1ab3a36c4592a4fe07cb608bebf) | `python38Packages.snowflake-connector-python: 2.6.0 -> 2.6.1`                               |
| [`cd4782bc`](https://github.com/NixOS/nixpkgs/commit/cd4782bc2fb62dc63fca3581d4af4324b07166cf) | `python38Packages.sphinxcontrib_httpdomain: 1.7.0 -> 1.8.0`                                 |
| [`9564ca51`](https://github.com/NixOS/nixpkgs/commit/9564ca5147358d74a6da0b6c9117e4e265ed1b77) | `python38Packages.transmission-rpc: 3.2.7 -> 3.2.8`                                         |
| [`24cd5844`](https://github.com/NixOS/nixpkgs/commit/24cd58440a06e79b7f8cd019f897c83abf56ddc9) | `python38Packages.toonapi: 0.2.0 -> 0.2.1`                                                  |
| [`34611790`](https://github.com/NixOS/nixpkgs/commit/346117904c6b2167ea602d47fd87a75063646cb2) | `python38Packages.tinydb: 4.5.1 -> 4.5.2`                                                   |
| [`1f2047b3`](https://github.com/NixOS/nixpkgs/commit/1f2047b3fa4ac99da16be1d286d7c5fbee589ec5) | `cargo-supply-chain: 0.0.2 -> 0.2.0`                                                        |
| [`6adf8ac2`](https://github.com/NixOS/nixpkgs/commit/6adf8ac2815e1e58a1ada7b72be46303abefc4d0) | `pantheon.elementary-photos: 2.7.1 -> 2.7.2`                                                |
| [`7dd555c5`](https://github.com/NixOS/nixpkgs/commit/7dd555c5acff8266b7e2cf7b84dc4ede4aff70fe) | `pantheon.gala: 6.0.1 -> 6.2.0`                                                             |
| [`24a85509`](https://github.com/NixOS/nixpkgs/commit/24a855097a7632e967852b1cbb70bb4b392acc2f) | `python3Packages.hiyapyco: allow later Jinja2 releases`                                     |
| [`912ee876`](https://github.com/NixOS/nixpkgs/commit/912ee876da7b92c2b298933abb2012c8f293a17c) | `Remove trailing whitespace`                                                                |
| [`ef950ca2`](https://github.com/NixOS/nixpkgs/commit/ef950ca2fd023e82dcede72c60e6c4b866c85440) | `python38Packages.r2pipe: 1.6.0 -> 1.6.2`                                                   |
| [`2417378e`](https://github.com/NixOS/nixpkgs/commit/2417378e35e5c4083c312ed78f8c9c6155483302) | `python38Packages.pytwitchapi: 2.3.0 -> 2.4.2`                                              |
| [`05cacac3`](https://github.com/NixOS/nixpkgs/commit/05cacac35c8f3778d157c8d5f3f8c1f253401f48) | `vimPlugins.vim-qlist: init at 2019-07-18`                                                  |
| [`7d9bcf3e`](https://github.com/NixOS/nixpkgs/commit/7d9bcf3e877edad1b9e7a9c68e9c8970e1b2bf00) | `vimPlugins.vim-argwrap: init at 2021-06-11`                                                |
| [`4b321e22`](https://github.com/NixOS/nixpkgs/commit/4b321e220446ca7ab05805a1e84f54d8d82bc357) | `python3Packages.censys: 2.0.7 -> 2.0.8`                                                    |
| [`7b401b2b`](https://github.com/NixOS/nixpkgs/commit/7b401b2b302ee798d86cf0d6d086253da595a333) | `vimPlugins.vim-argumentative: init at 2014-11-24`                                          |
| [`917fa7ae`](https://github.com/NixOS/nixpkgs/commit/917fa7aeff1e708c8309086bffe68a69de2d3c67) | `python3Packages.pontos: switch to poetry-core`                                             |
| [`fda09976`](https://github.com/NixOS/nixpkgs/commit/fda09976e7c89353ccc47e4b064cd6569c8139da) | `tlsh: 4.9.3 -> 4.10.0`                                                                     |
| [`924cbbd2`](https://github.com/NixOS/nixpkgs/commit/924cbbd2fdbd3bdb0f4c79d34ff0933d60b08f66) | `privacyidea: explicitly use fetchPypi in flask-migrate override`                           |
| [`38d1ee33`](https://github.com/NixOS/nixpkgs/commit/38d1ee33e9998ae5e2636fa558a4f770b7824069) | `python3Packages.flask-migrate: fix build`                                                  |
| [`f4db4059`](https://github.com/NixOS/nixpkgs/commit/f4db40591019666f0821e36ee3f9023ab122bcfa) | `python3Packages.priority: fix build, refactor package`                                     |
| [`c9dcfe33`](https://github.com/NixOS/nixpkgs/commit/c9dcfe33a8f008b11e0276e4f2d0649e172034cc) | `python3Packages.openshift: relax kubernetes constraint`                                    |
| [`bf2a7163`](https://github.com/NixOS/nixpkgs/commit/bf2a71631fdeb5719492bfeaf9f0fca6170f2c2e) | `python3Packages.kubernetes: fix build, refactor`                                           |
| [`75fec749`](https://github.com/NixOS/nixpkgs/commit/75fec7494be462a771e5697af71b8644cb8521c6) | `python38Packages.pybullet: 3.1.8 -> 3.1.9`                                                 |
| [`2169cfd8`](https://github.com/NixOS/nixpkgs/commit/2169cfd85284126b61e89ef03468f5078a8acc79) | `auto-cpufreq: fix version output`                                                          |
| [`889dba01`](https://github.com/NixOS/nixpkgs/commit/889dba01cce5ea45a2bd733f671eee7cb6818cff) | `python38Packages.pontos: 21.9.0 -> 21.9.1`                                                 |
| [`c743750a`](https://github.com/NixOS/nixpkgs/commit/c743750aca50ad71c284993cf2a75dd88b7a8215) | `python38Packages.pikepdf: 3.0.0 -> 3.1.0`                                                  |
| [`6219c9b3`](https://github.com/NixOS/nixpkgs/commit/6219c9b363e2c06378cbca5b55e0acd109540864) | `python38Packages.parts: 1.1.0 -> 1.1.2`                                                    |
| [`e1c56ff2`](https://github.com/NixOS/nixpkgs/commit/e1c56ff290fe78847082dacc1ea33aaa564e2098) | `python3Packages.auth0-python: 3.17.0 -> 3.18.0`                                            |
| [`beea0747`](https://github.com/NixOS/nixpkgs/commit/beea07475e02a11915181f352500b818999601cd) | `python3Packages.biplist: diasble failing tests`                                            |
| [`49ec311b`](https://github.com/NixOS/nixpkgs/commit/49ec311b53db1d5cc7e452b06d8a8d3e55b60fb3) | `python38Packages.mypy-boto3-s3: 1.18.29 -> 1.18.46`                                        |
| [`89d061ac`](https://github.com/NixOS/nixpkgs/commit/89d061aca1e673cb9ad4c5709a192ac670f01daf) | `python38Packages.mocket: 3.9.44 -> 3.10.0`                                                 |
| [`9f07894e`](https://github.com/NixOS/nixpkgs/commit/9f07894ef01700ca8f36f76b0a27fc686e45326a) | `python38Packages.mne-python: 0.23.3 -> 0.23.4`                                             |
| [`a34d3583`](https://github.com/NixOS/nixpkgs/commit/a34d3583930abb8b6a26012d68c3471ecd8e1d32) | `python38Packages.mechanize: 0.4.6 -> 0.4.7`                                                |
| [`f0f08efd`](https://github.com/NixOS/nixpkgs/commit/f0f08efd5f0f0a81d8cd4ef916690dd3c7d2e95d) | `meli: alpha-0.6.2 -> alpha-0.7.1`                                                          |
| [`02b6fe2c`](https://github.com/NixOS/nixpkgs/commit/02b6fe2cb20a1a520c49504c4c6afde37863829e) | `python38Packages.labgrid: 0.3.3 -> 0.4.0`                                                  |