### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9540c5f121d77c68de0f2156cb6f9869d95a6f8",
-        "sha256": "0s0i6x78nxjyc0a885hzvwh5bylccixiam6c5h1q6pa64aqx50pc",
+        "rev": "92ad52c05ed9cc40ef7ebe51a1a2cb3c95777e8f",
+        "sha256": "1d483q9qphnsikgl4lvh3znpq3daacgszv2xqbzfh0c2j8ji8cfm",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9540c5f121d77c68de0f2156cb6f9869d95a6f8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/92ad52c05ed9cc40ef7ebe51a1a2cb3c95777e8f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`383b3b36`](https://github.com/NixOS/nixpkgs/commit/383b3b36d06bddd730acbb466f66af5b7bee913a) | `mop: fix build on bash-5`                                                  |
| [`54cecf8b`](https://github.com/NixOS/nixpkgs/commit/54cecf8bdee6f4eeb9a9a3b4917ceebe51e8b18d) | `tailscale: 1.14.3 -> 1.14.4`                                               |
| [`f40924a4`](https://github.com/NixOS/nixpkgs/commit/f40924a499b405becc41b9c869f64ef0ac5b4b5b) | `vscode: apply postPatch on linux only`                                     |
| [`7a038d04`](https://github.com/NixOS/nixpkgs/commit/7a038d04c64c81470e8691e19ee371a4d1aac178) | `pantheon.gala: fix session crash when taking screenshots with mutter 3.38` |
| [`5fdb0a6c`](https://github.com/NixOS/nixpkgs/commit/5fdb0a6cafff7c41107fdd80e306b47a1bc54718) | `joshuto: 0.9.0 -> 0.9.1`                                                   |
| [`be3bc77e`](https://github.com/NixOS/nixpkgs/commit/be3bc77e3175f055e634ca1375d7cbdb60facfad) | `libnatpmp: make files in $out/lib executable`                              |
| [`d472c9d8`](https://github.com/NixOS/nixpkgs/commit/d472c9d87c6fea330660c2bc079e0e6b607e4c40) | `python3Packages.pyspcwebgw: init at 0.5.0`                                 |
| [`c9ebf4ed`](https://github.com/NixOS/nixpkgs/commit/c9ebf4ed8001e51fdbf976862a2f04d9d580f9b9) | `home-assistant: enable spc tests`                                          |
| [`9c0e8584`](https://github.com/NixOS/nixpkgs/commit/9c0e8584e9fd1ed8e1faa5e09097916f7e387730) | `home-assistant: update component-packages`                                 |
| [`4d7751ad`](https://github.com/NixOS/nixpkgs/commit/4d7751adb6ed5a7bec4a9930ff5f714cad48a995) | `home-assistant: update component-packages`                                 |
| [`5c8bd5a5`](https://github.com/NixOS/nixpkgs/commit/5c8bd5a5ef26da8a555e64c5e4e93efbf75c3b93) | ` python3Packages.streamlabswater: init at 0.3.2`                           |
| [`fb972569`](https://github.com/NixOS/nixpkgs/commit/fb9725692f7b765617a800bdc92d9b4cc37f69d0) | `python3Packages.asynccmd: init at 0.2.4`                                   |
| [`450c0ab5`](https://github.com/NixOS/nixpkgs/commit/450c0ab5e7686b8a595024a91a9b5a29d2209765) | `ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-rc2 → 4.13.0`                    |
| [`e6cc081a`](https://github.com/NixOS/nixpkgs/commit/e6cc081a42c3f2dfe7fa363da6408fbc359648e5) | `github-backup: 0.40.0 -> 0.40.1`                                           |
| [`5a0c59bb`](https://github.com/NixOS/nixpkgs/commit/5a0c59bb4dd90bb6103822daaa30bf2fbc70da67) | `python3Packages.xml2rfc: 3.9.1 -> 3.10.0`                                  |
| [`6e20be97`](https://github.com/NixOS/nixpkgs/commit/6e20be978b1aea35bfb1da4ef39200d72a9a74ed) | `chatterino2: 2.3.0 -> 2.3.4`                                               |
| [`1ae69f0d`](https://github.com/NixOS/nixpkgs/commit/1ae69f0dce7db8ea0494aacd2e302b5158ed0ec5) | `cutter: 2.0.2 -> 2.0.3`                                                    |
| [`63eb37d2`](https://github.com/NixOS/nixpkgs/commit/63eb37d2cade10d66a5c00f8da5e98adf7ed3b54) | `rizin: 0.2.1 -> 0.3.0`                                                     |
| [`5ad2ce9d`](https://github.com/NixOS/nixpkgs/commit/5ad2ce9dca210123762cb1dbb6f5c81c31c25f0d) | `vsce/asvetliakov.vscode-neovim: init at 0.0.82`                            |
| [`69cb5e3d`](https://github.com/NixOS/nixpkgs/commit/69cb5e3dc6bfd0ae2eb4d0eb9b8c2810d798cc05) | `nixos/owncast: release notes`                                              |
| [`0593b0a4`](https://github.com/NixOS/nixpkgs/commit/0593b0a4de51bfdbc3e2e8be368ee9012381afad) | `nomad_1_1: 1.1.4 -> 1.1.5`                                                 |
| [`f9756aa1`](https://github.com/NixOS/nixpkgs/commit/f9756aa1d9ad47c73198bebca8ef473f15305fca) | `nomad_1_0: 1.0.10 -> 1.0.11`                                               |
| [`ec54e608`](https://github.com/NixOS/nixpkgs/commit/ec54e6081866b22bead1f4951c6af05b027724e9) | `home-assistant: enable flipr tests`                                        |
| [`b5802f42`](https://github.com/NixOS/nixpkgs/commit/b5802f427f0d7ad351d6e789fa4deb62f5838c62) | `home-assistant: update component-packages`                                 |
| [`d038da0a`](https://github.com/NixOS/nixpkgs/commit/d038da0ab4cf98699af1b5821172ce19a96c27fa) | `python3Packages.flipr-api: init at 1.4.1`                                  |
| [`b6678803`](https://github.com/NixOS/nixpkgs/commit/b6678803d1cb8baabb87939ff31735755ec08885) | `navi: 2.16.0 -> 2.17.0`                                                    |
| [`48c21d8c`](https://github.com/NixOS/nixpkgs/commit/48c21d8c273dbe5427e22545073b58adc4fba930) | `python38Packages.ytmusicapi: 0.19.2 -> 0.19.3`                             |
| [`fc43bfa5`](https://github.com/NixOS/nixpkgs/commit/fc43bfa5f452fd19e246a14fdab0ac0ce86d0ed4) | `home-assistant: enable hunterdouglas_powerview tests`                      |
| [`86690c93`](https://github.com/NixOS/nixpkgs/commit/86690c930c571860717de155162326e2a5afde1b) | `home-assistant: update component-packages`                                 |
| [`75f3b984`](https://github.com/NixOS/nixpkgs/commit/75f3b98431f89c0313a75447fec3e85419a85bee) | `python3Packages.aiopvapi: init at 1.6.14`                                  |
| [`3d650ad7`](https://github.com/NixOS/nixpkgs/commit/3d650ad7d17f49b9b5f8ae64c3463d410d6b0b43) | `home-assistant: update component-packages`                                 |
| [`e96405f6`](https://github.com/NixOS/nixpkgs/commit/e96405f686b7a4e1341c25f82c1300354819e0c4) | `home-assistant: update component-packages`                                 |
| [`ed04c57d`](https://github.com/NixOS/nixpkgs/commit/ed04c57df977cca53b702dac7268774a2560e2b4) | `python3Packages.eternalegypt: init at 0.0.13`                              |
| [`b9317c9e`](https://github.com/NixOS/nixpkgs/commit/b9317c9ed1c9261e3fbde8d16fac60ec665b02e5) | `home-assistant: enable renault tests`                                      |
| [`9aa02e78`](https://github.com/NixOS/nixpkgs/commit/9aa02e78e14a0ff1994574c50377184abf7237ab) | `home-assistant: update component-packages`                                 |
| [`f6ce10aa`](https://github.com/NixOS/nixpkgs/commit/f6ce10aac7c645f637997412c193eaea323499a9) | `python3Packages.renault-api: init at 0.1.4`                                |
| [`7a08ed05`](https://github.com/NixOS/nixpkgs/commit/7a08ed05f64a4ce14dfcf7c8a4f8db507a5d07a4) | `python3Packages.marshmallow-dataclass: init at 8.5.3`                      |
| [`1bac76f0`](https://github.com/NixOS/nixpkgs/commit/1bac76f06fbdcb5d0ea0e18e9dae359c942825da) | `racket: unbreak on darwin`                                                 |
| [`5b2139ea`](https://github.com/NixOS/nixpkgs/commit/5b2139eadc55f9cbc09e19d6654132928992565b) | `python38Packages.filetype: 1.0.7 -> 1.0.8`                                 |
| [`7704e229`](https://github.com/NixOS/nixpkgs/commit/7704e2298404057d0a89a5c1ee04cc20c134b0b7) | `home-assistant: enable p1_monitor tests`                                   |
| [`2d4c7f67`](https://github.com/NixOS/nixpkgs/commit/2d4c7f67cc404b2163c067bdbe738da9ea08bb27) | `home-assistant: update component-packages`                                 |
| [`28580344`](https://github.com/NixOS/nixpkgs/commit/28580344231bd73178a888430a36852292547e99) | `python3Packages.p1monitor: init at 1.0.0`                                  |
| [`f1ae15c4`](https://github.com/NixOS/nixpkgs/commit/f1ae15c4e7e5c58a8cafa0927ee9da19f76b4a4c) | `python3Packages.iotawattpy: init at 0.1.0`                                 |
| [`c3875017`](https://github.com/NixOS/nixpkgs/commit/c38750173d82346cfcc0c427c1dead5d691d611d) | `python3Packages.aiowatttime: init at 0.1.1`                                |
| [`1e4ccb74`](https://github.com/NixOS/nixpkgs/commit/1e4ccb742211dfef182fe9013cd6fd8c80111ed4) | `python3Packages.pyupgrade: 2.26.0 -> 2.27.0`                               |
| [`813c400e`](https://github.com/NixOS/nixpkgs/commit/813c400edc0802a16c9c4b305f111b7f9b22c537) | `cntk: fix build with protobuf 3.18+`                                       |
| [`3e47e8d1`](https://github.com/NixOS/nixpkgs/commit/3e47e8d1cffb45bd0f1d5e481faa1b01dfa2d420) | `rabbitmq-server: 3.9.4 -> 3.9.6`                                           |
| [`1f934dad`](https://github.com/NixOS/nixpkgs/commit/1f934dad304efab18eb2be404323ce9a3218902d) | `nixos/owncast: init owncast service`                                       |
| [`0c350944`](https://github.com/NixOS/nixpkgs/commit/0c350944709004cf29645601d6e886dcaeba6a0c) | `openvino: fix build with protobuf 3.18+`                                   |
| [`6a01398c`](https://github.com/NixOS/nixpkgs/commit/6a01398cccc010b0c91cade3dbabc6cfacdd72dc) | `valhalla: fix build with protobuf 3.18+`                                   |
| [`e1280221`](https://github.com/NixOS/nixpkgs/commit/e12802213e5ee50ff95eac9fd25d6a4a3338abb4) | `caffe: fix build with protobuf 3.18+`                                      |
| [`f0796912`](https://github.com/NixOS/nixpkgs/commit/f0796912bc1603910be26d2bd5fc6365b003f8c5) | `owncast: init at 0.0.8`                                                    |
| [`c6b56fbf`](https://github.com/NixOS/nixpkgs/commit/c6b56fbf588375c8440966677a6a54fc146e7ff1) | `fetchfirefoxaddon: add simple test`                                        |
| [`be9e94d4`](https://github.com/NixOS/nixpkgs/commit/be9e94d42c87a5c26c66c005286773b4dfbc9070) | `gnome-doc-utils: switch to python3`                                        |
| [`e2ccaaa9`](https://github.com/NixOS/nixpkgs/commit/e2ccaaa9be388a75c5022487b5585480a5cd08cc) | `menumaker: 0.99.12 -> 0.99.13 and switch to python3`                       |
| [`eef7318c`](https://github.com/NixOS/nixpkgs/commit/eef7318c71826943602e276dc1fe1908ece7c7a4) | `linuxPackages_5_13.system76-power: 1.1.16 -> 1.1.17`                       |