### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "92ad52c05ed9cc40ef7ebe51a1a2cb3c95777e8f",
-        "sha256": "1d483q9qphnsikgl4lvh3znpq3daacgszv2xqbzfh0c2j8ji8cfm",
+        "rev": "1737f98af6667560e3e4f930312f9b5002649d04",
+        "sha256": "0jdiw9wjyqvbrnigwjxinars6203ql550f0wlp70j1rr7cn7fmjz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/92ad52c05ed9cc40ef7ebe51a1a2cb3c95777e8f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1737f98af6667560e3e4f930312f9b5002649d04.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                 |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`9b5dd003`](https://github.com/NixOS/nixpkgs/commit/9b5dd00333775ca9be0d9ac67cc00755708ec494) | `wsdd: 0.6.2 -> 0.6.4`                                         |
| [`8bf6ca43`](https://github.com/NixOS/nixpkgs/commit/8bf6ca43cbaef0de2bfa031f9c8f6dc2bff8001f) | `python38Packages.pytelegrambotapi: 4.0.0 -> 4.1.0`            |
| [`7c86d105`](https://github.com/NixOS/nixpkgs/commit/7c86d10590ccc5330fed0866fe937faf3e36f7a3) | `texinfo6_8: init at 6.8 (without switching default)`          |
| [`61da8692`](https://github.com/NixOS/nixpkgs/commit/61da86928406435694525d7b9553f6ee2703fd77) | `apostrophe: 2.4 -> 2.5`                                       |
| [`fe6701ec`](https://github.com/NixOS/nixpkgs/commit/fe6701ec3ab3ede6f53d6f014fe1db80b83d0fa7) | `packer: 1.7.4 -> 1.7.5`                                       |
| [`20706e94`](https://github.com/NixOS/nixpkgs/commit/20706e94085b79340cbdd28abcb9f5f4da9883f1) | `python3Packages.pytibber: update description`                 |
| [`d859c439`](https://github.com/NixOS/nixpkgs/commit/d859c439d20da9341d826768f0a830550fbf46d0) | `python3Packages.pytibber: 0.19.1 -> 0.20.0`                   |
| [`293c04c6`](https://github.com/NixOS/nixpkgs/commit/293c04c6a9898847f6c22d9bd4bc83e8f3434b8d) | `python3Packages.mypy-boto3-builder: 4.22.1 -> 5.4.0`          |
| [`aef78fae`](https://github.com/NixOS/nixpkgs/commit/aef78fae439df7663e4e2268fc8230d5bedebb63) | `python3Packages.mypy-boto3-builder: 4.14.1 -> 4.22.1`         |
| [`4e276096`](https://github.com/NixOS/nixpkgs/commit/4e27609642ce2a57539c103ca9a995ad761d53aa) | `exploitdb: 2021-09-22 -> 2021-09-25`                          |
| [`2eb62bb9`](https://github.com/NixOS/nixpkgs/commit/2eb62bb92e78402557b9f7fe38561f1154ad1aee) | `tfsec: 0.58.9 -> 0.58.10`                                     |
| [`33d3f1d8`](https://github.com/NixOS/nixpkgs/commit/33d3f1d8207a411d5b343c74e409cab3a2608788) | `python38Packages.fountains: 1.1.0 -> 1.1.1`                   |
| [`5fa508d9`](https://github.com/NixOS/nixpkgs/commit/5fa508d98fe3de78fe8e882ce703ea9ee7144468) | `python38Packages.fe25519: 0.2.0 -> 0.3.0`                     |
| [`ecd33477`](https://github.com/NixOS/nixpkgs/commit/ecd334772cdf2a57bab4d88ec6f761e2ba38e420) | `python38Packages.emoji: 1.5.0 -> 1.5.2`                       |
| [`628f61fe`](https://github.com/NixOS/nixpkgs/commit/628f61fe1a5830787ae359aa61be877858c36100) | `python38Packages.deezer-py: 1.2.3 -> 1.2.4`                   |
| [`d032f60c`](https://github.com/NixOS/nixpkgs/commit/d032f60c37ebdae3afd9a24212497ec8725ee4fb) | `ghcjs: Enable on darwin (#139067)`                            |
| [`8d77e899`](https://github.com/NixOS/nixpkgs/commit/8d77e899e89f8828b211ee66265aa177ad038eca) | `sasquatch: drop blanket -Werror (fix gcc-11 build) (#139350)` |
| [`f1a8d087`](https://github.com/NixOS/nixpkgs/commit/f1a8d087eb59b4513b37873c4b96bf7d63ec41b1) | `cargo-feature: 0.5.2 -> 0.5.3`                                |
| [`bd0ea729`](https://github.com/NixOS/nixpkgs/commit/bd0ea72925ec64f0613240894313ad778871e477) | `python38Packages.casbin: 1.8.1 -> 1.9.0`                      |
| [`d3e59373`](https://github.com/NixOS/nixpkgs/commit/d3e59373610389ff65ff025231c70695362b09dc) | `python3Packages.imdbpy: remove patch`                         |
| [`fce1ac0d`](https://github.com/NixOS/nixpkgs/commit/fce1ac0d62b496d11f5dd4700524f92c2b844905) | `sqlfluff: 0.6.5 -> 0.6.6`                                     |
| [`cda1e497`](https://github.com/NixOS/nixpkgs/commit/cda1e49784034826eb04a67cfe6fff5e226cc609) | `foreman: add more platform support`                           |
| [`c3330fa7`](https://github.com/NixOS/nixpkgs/commit/c3330fa752d2fa06d6f8ad68d535152fb9d1d778) | `cpio: clean up the nix expression`                            |
| [`3194ce02`](https://github.com/NixOS/nixpkgs/commit/3194ce025c746acdc5460a7a7d4fff298ba6a3e5) | `cpio: add two subsequent upstream patches`                    |
| [`539b9b26`](https://github.com/NixOS/nixpkgs/commit/539b9b26aa702e5114595ecb58ae36ebde6ee62b) | `home-assistant: update component-packages`                    |
| [`048af0cd`](https://github.com/NixOS/nixpkgs/commit/048af0cd5ff53c31eff561b25b9b558e62f82817) | `python3Packages.niluclient: init at 0.1.2`                    |
| [`5ff1057e`](https://github.com/NixOS/nixpkgs/commit/5ff1057ec4134d76481d9761ebed76d1cb1d3452) | `python3Packages.types-requests: 2.25.8 -> 2.25.9`             |
| [`c4fc5f5d`](https://github.com/NixOS/nixpkgs/commit/c4fc5f5dda7a87317e7d9856c30a2e4f4c3f19cf) | `home-assistant: update component-packages`                    |
| [`9d6fbb6b`](https://github.com/NixOS/nixpkgs/commit/9d6fbb6b2cb036c8206e3bfb18aafc13493f286a) | `python3Packages.pysdcp: init at 1`                            |
| [`3512d59e`](https://github.com/NixOS/nixpkgs/commit/3512d59e6c263adc82dabfe6effaa59d18fcd79c) | `python3Packages.velbus-aio: 2021.9.2 -> 2021.9.4`             |
| [`bb083e62`](https://github.com/NixOS/nixpkgs/commit/bb083e6229266cda7561d64c2eb95f2f07670b91) | `python3Packages.pysiaalarm: 3.0.0 -> 3.0.1`                   |
| [`78d06ff3`](https://github.com/NixOS/nixpkgs/commit/78d06ff3f35376e0f104b6b1a92a2630572d1df8) | `python3Packages.aioymaps: 1.1.0 -> 1.2.0`                     |
| [`66bbe453`](https://github.com/NixOS/nixpkgs/commit/66bbe45347a56d2e35b6cb3c8c21a3c1077055d1) | `python3Packages.pyroute2-ipset: 0.6.4 -> 0.6.5`               |
| [`22b76aab`](https://github.com/NixOS/nixpkgs/commit/22b76aab57c780192c5af19fbf4823ef7f917050) | `python3Packages.pyroute2: 0.6.4 -> 0.6.5`                     |
| [`6b5cb97a`](https://github.com/NixOS/nixpkgs/commit/6b5cb97a54aac3b28d40a0be10a7cbffedffd680) | `python3Packages.pyroute2-protocols: 0.6.4 -> 0.6.5`           |
| [`b1143f61`](https://github.com/NixOS/nixpkgs/commit/b1143f619defb8c0acef54c6db6a3eb586beab66) | `python3Packages.pyroute2-nslink: 0.6.4 -> 0.6.5`              |
| [`26c76482`](https://github.com/NixOS/nixpkgs/commit/26c764828aea32a740bfaf3eabaf72ad8432c23d) | `python3Packages.pyroute2-nftables: 0.6.4 -> 0.6.5`            |
| [`25a95d52`](https://github.com/NixOS/nixpkgs/commit/25a95d5252614ac31fa75c3b5b8694e50152505c) | `python3Packages.pyroute2-ndb: 0.6.4 -> 0.6.5`                 |
| [`3e36c10f`](https://github.com/NixOS/nixpkgs/commit/3e36c10fa07ad9bc7b760e04f4c2ae2a821a6775) | `python3Packages.pyroute2-ipdb: 0.6.4 -> 0.6.5`                |
| [`5a8bb0de`](https://github.com/NixOS/nixpkgs/commit/5a8bb0de979a9bf5cc620aca354dc9970984863e) | `python3Packages.pyroute2-ethtool: 0.6.4 -> 0.6.5`             |
| [`edea8f2f`](https://github.com/NixOS/nixpkgs/commit/edea8f2f2742fe375cfcfa2988f8e1f005f016ec) | `python3Packages.pyroute2-core: 0.6.4 -> 0.6.5`                |
| [`21fdca87`](https://github.com/NixOS/nixpkgs/commit/21fdca8720c596f923c7b22121f53126b08e402c) | `python3Packages.arcam-fmj: 0.11.1 -> 0.12.0`                  |
| [`d380611b`](https://github.com/NixOS/nixpkgs/commit/d380611baa5d502576c5da315431de7d82327f33) | `python3Packages.yeelight: 0.7.4 -> 0.7.5`                     |
| [`127ac80e`](https://github.com/NixOS/nixpkgs/commit/127ac80e92ddb47297c8e3c24408e19fc6fd8554) | `python3Packages.screenlogicpy: 0.4.2 -> 0.4.3`                |
| [`3715f0a3`](https://github.com/NixOS/nixpkgs/commit/3715f0a3fa9981f538e1d29c05cb881734b78389) | `python3Packages.pyvolumio: 0.1.3 -> 0.1.4`                    |
| [`5717b97d`](https://github.com/NixOS/nixpkgs/commit/5717b97d6ad3385e39ac80a841a5e372ae0a2f57) | `openapi-generator-cli: 5.2.0 -> 5.2.1`                        |