### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af45dae72dc6288f07af7af0dd1b93f9c906065b",
-        "sha256": "1phws03l6azp00673mf12n3cn66kyifqk5brfn0a27ij8dg2ns7l",
+        "rev": "e0f52be5659343620d917e71c41e00acad6e3678",
+        "sha256": "05vwhjb0inj8m0kskyyzxr2jymjhwh5h4f2csvsjyp1rv62bcd64",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/af45dae72dc6288f07af7af0dd1b93f9c906065b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e0f52be5659343620d917e71c41e00acad6e3678.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`35cad8da`](https://github.com/NixOS/nixpkgs/commit/35cad8da44b44a174798e19d03b81bd995ac5de0) | `heroku: remove peterhoeg as maintainer`                                     |
| [`35dbdedf`](https://github.com/NixOS/nixpkgs/commit/35dbdedf6337ffe6a003990697b114bea728b11a) | `vala: not using vala`                                                       |
| [`aed860f8`](https://github.com/NixOS/nixpkgs/commit/aed860f87662825abdad405b0b5008013e42d042) | `nixos/zoneminder: not using zoneminder any longer`                          |
| [`abc36451`](https://github.com/NixOS/nixpkgs/commit/abc36451d78d4c36a57a3acc7ce2f08e40789e72) | `lua: create a folder for hooks`                                             |
| [`ba6a2ecc`](https://github.com/NixOS/nixpkgs/commit/ba6a2ecc641312e31983405491b8b4233f2b0b98) | `wine: only embed mono & gecko installers in winePackages.full`              |
| [`a92a208a`](https://github.com/NixOS/nixpkgs/commit/a92a208a9d8eaba19a5d985f567387adea455687) | `linux/hardened/patches/5.4: 5.4.148-hardened1 -> 5.4.149-hardened1`         |
| [`05ed561f`](https://github.com/NixOS/nixpkgs/commit/05ed561fb6de4fce668d5c5d1c2c7ae18ab8aff5) | `linux/hardened/patches/5.14: 5.14.7-hardened1 -> 5.14.8-hardened1`          |
| [`c4ea02fc`](https://github.com/NixOS/nixpkgs/commit/c4ea02fc5c468ebd06f9575eb764ad4d08c8fdd6) | `linux/hardened/patches/5.10: 5.10.68-hardened1 -> 5.10.69-hardened1`        |
| [`9e78068b`](https://github.com/NixOS/nixpkgs/commit/9e78068b041dfebbac36958d6745bc3ef2415d5d) | `linux/hardened/patches/4.19: 4.19.207-hardened1 -> 4.19.208-hardened1`      |
| [`1e05c4ea`](https://github.com/NixOS/nixpkgs/commit/1e05c4eae9ec704b7057dcec87cf5007d6a081ac) | `linux/hardened/patches/4.14: 4.14.247-hardened1 -> 4.14.248-hardened1`      |
| [`f5f386d2`](https://github.com/NixOS/nixpkgs/commit/f5f386d297f8ba8e5527c78de2f11b12daded6f6) | `nixos/syncoid: Delegate permissions to parent dataset if target is missing` |
| [`e9bd47e6`](https://github.com/NixOS/nixpkgs/commit/e9bd47e681ae711b522674953e2e17d657adfc99) | `pkgsi686Linux.pkgsStatic.libgpgerror: fix build`                            |
| [`05bdbc55`](https://github.com/NixOS/nixpkgs/commit/05bdbc55ffb15fbbf92a487664f1d4421542cb90) | `plasma5Packages: add missing homepages and descriptions`                    |
| [`bf12e3f2`](https://github.com/NixOS/nixpkgs/commit/bf12e3f2a3ad2a937955661a2d169e2c9fc25188) | `weechatScripts.zncplayback: init at 0.2.1`                                  |
| [`860b938b`](https://github.com/NixOS/nixpkgs/commit/860b938bbf27d6b44d0ea60ec5a0ff1320072291) | `capnproto: fix cross`                                                       |
| [`3fc12275`](https://github.com/NixOS/nixpkgs/commit/3fc12275e6029b4622051ede24c45f0e4168aeea) | `pkgsStatic.capnproto: fix build`                                            |
| [`a954cb10`](https://github.com/NixOS/nixpkgs/commit/a954cb109d7560e79ff3149240f360747f02a685) | `ocr-a: init at 1.0`                                                         |
| [`7005f1e6`](https://github.com/NixOS/nixpkgs/commit/7005f1e6e25968de72e67a93fc8116bc8263dffb) | `neovim: 0.5.0 -> 0.5.1`                                                     |
| [`66afaccb`](https://github.com/NixOS/nixpkgs/commit/66afaccb81c8db8294bbd8d5476c96bfaf33570f) | `luaPackages: update`                                                        |
| [`8278a467`](https://github.com/NixOS/nixpkgs/commit/8278a4679be8088c5353ffac78de2687b21d6d3b) | `luaPackages.luv: 1.30.0-0 -> 1.42.0-0`                                      |
| [`a72cf113`](https://github.com/NixOS/nixpkgs/commit/a72cf113d8d6f8dbdb5ef8037702b2c31d90111f) | `Update pkgs/applications/audio/spot/default.nix`                            |
| [`7d38eec7`](https://github.com/NixOS/nixpkgs/commit/7d38eec7c55730af4e74049f2f7e6cb122ddff2c) | `qlandkartegt: use proj_7`                                                   |
| [`98c8fc6f`](https://github.com/NixOS/nixpkgs/commit/98c8fc6fd01749b3aa7f28516ebfdefaab079cab) | `gplates: 2.2.0 -> 2.3.0`                                                    |
| [`7e6325ef`](https://github.com/NixOS/nixpkgs/commit/7e6325efd413bd72df9b9a89af9669f843120b11) | `python3Packages.geopandas: fix tests`                                       |
| [`042eebd8`](https://github.com/NixOS/nixpkgs/commit/042eebd8d91c16fbe44186bbf33b478c9edb780b) | `qgis: fix build with PROJ 8`                                                |
| [`365413e2`](https://github.com/NixOS/nixpkgs/commit/365413e22fc68bb7e7695f29b21dd3fd7d3bf3f4) | `catcli: 0.7.2 -> 0.7.3`                                                     |
| [`afb755e7`](https://github.com/NixOS/nixpkgs/commit/afb755e7067f83beadc5b290f153d77b77326be0) | `buildCrystalPackage: use --no-debug`                                        |
| [`9bd941c5`](https://github.com/NixOS/nixpkgs/commit/9bd941c5d2627f0cac739aab90c22e8e34733273) | `crystal,shards: remove old versions`                                        |
| [`946154fd`](https://github.com/NixOS/nixpkgs/commit/946154fdb77cea5898e281393c731966c09b10a6) | `thicket: 0.1.4 -> 0.1.5`                                                    |
| [`9a3ed0e8`](https://github.com/NixOS/nixpkgs/commit/9a3ed0e8c501bc4631d7dedaa06e8393704bf146) | `buildCrystalPackage: redirect stdout to /dev/null`                          |
| [`51e3c659`](https://github.com/NixOS/nixpkgs/commit/51e3c659a08a742c1ce83f955cd039b02eb293b3) | `crystal: increase build cores`                                              |
| [`6900e477`](https://github.com/NixOS/nixpkgs/commit/6900e4773d270b8ba37a5088dd71e05f9acf2cbd) | `crystal_0_36: add a binary bootstrap variant`                               |
| [`0f555888`](https://github.com/NixOS/nixpkgs/commit/0f55588885d9e93d8cb860545822a6ad3dc8bb00) | `shards: 0.14 -> 0.15`                                                       |
| [`b5e86fa7`](https://github.com/NixOS/nixpkgs/commit/b5e86fa70094de98d721f7f32f60fa31157b066a) | `firestarter: don't reference nvidia_x11 directly`                           |
| [`7ba89a2e`](https://github.com/NixOS/nixpkgs/commit/7ba89a2e22ebd4c0aa014ae21982c32f8020f6ec) | `python3Packages.tensorflow-bin: remove nvidia_x11 reference`                |
| [`c826ba3f`](https://github.com/NixOS/nixpkgs/commit/c826ba3f6ba8c8be7a2a983d42a79f4115afeb63) | `mapnik: mark as broken`                                                     |
| [`0b97370e`](https://github.com/NixOS/nixpkgs/commit/0b97370eb9124d58dc2322467bea7ea7564f75df) | `python3Packages.cartopy: 0.19.0.post1 -> 0.20.0`                            |
| [`68ef9d8c`](https://github.com/NixOS/nixpkgs/commit/68ef9d8c663e07e5f3d7837ef574b46c08452b01) | `python3Packages.pyproj: 3.1.0 -> 3.2.1`                                     |
| [`71666e18`](https://github.com/NixOS/nixpkgs/commit/71666e18f1af11a8737dca7d6f67589b3977109e) | `proj: 7.2.1 -> 8.1.1`                                                       |
| [`b51c3c22`](https://github.com/NixOS/nixpkgs/commit/b51c3c22d5c09b0e2b618cebdf88accd007343e7) | `survex: use proj_7`                                                         |
| [`b73a99ed`](https://github.com/NixOS/nixpkgs/commit/b73a99edcb559caeb80b137fa6286d02b2d4def4) | `xygrib: use proj_7`                                                         |
| [`3553854f`](https://github.com/NixOS/nixpkgs/commit/3553854f1297cd9ec0ab8b1acc47c10406ddf76d) | `osm2xmap: use proj7`                                                        |
| [`cb1fc48d`](https://github.com/NixOS/nixpkgs/commit/cb1fc48dcef7fb1d56f1d2c2c8e8c00b5c188d37) | `proj_7: init at 7.2.1`                                                      |
| [`3dfef5d4`](https://github.com/NixOS/nixpkgs/commit/3dfef5d4b58cd9f0f8ddd77c1806f51bd0fd8692) | `python38Packages.mypy-boto3-s3: 1.18.47 -> 1.18.48`                         |
| [`65605178`](https://github.com/NixOS/nixpkgs/commit/65605178bffcf2f6afb761ac3df427b812a6887f) | `pass-git-helper: 1.1.1 -> 1.1.2`                                            |
| [`ab729b57`](https://github.com/NixOS/nixpkgs/commit/ab729b57654724d02b9ba8be5fc9d9be086ecd10) | `xfce.xfdashboard: 0.9.3 -> 0.9.4`                                           |
| [`5b1c9a9f`](https://github.com/NixOS/nixpkgs/commit/5b1c9a9fc997a7e5b69c034c21e742ca59389773) | `xfce.thunar: 4.16.9 -> 4.16.10`                                             |
| [`2f669293`](https://github.com/NixOS/nixpkgs/commit/2f669293bfb99dd71bb9e69048aee7132b060870) | `prometheus-fastly-exporter: init at v6.1.0`                                 |
| [`3db41812`](https://github.com/NixOS/nixpkgs/commit/3db41812bbf14d672803b941581268c42afec815) | `spot: Build an optimised binary, to drop CPU usage: 70% -> 10%`             |