### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6fa4e75f7622ccedee8cb58a8d2ecaa658667a10",
-        "sha256": "1f4i71z30i9rfrvaapahwbhwj8zwl20yh1dgzpmbfh4x4zgxdnsd",
+        "rev": "0699530f08290f34c532beedd66046825d9756fa",
+        "sha256": "1845czci6i1jj85mpr2yjvxr8kr9nqmlpimggfb6zxndzyb5n8zx",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6fa4e75f7622ccedee8cb58a8d2ecaa658667a10.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0699530f08290f34c532beedd66046825d9756fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`63df91f7`](https://github.com/NixOS/nixpkgs/commit/63df91f789fd973ece46ad9547f6a72ea7dfb231) | `coqPackages.coq-ext-lib: 0.11.3 → 0.11.4`                                        |
| [`c50a069e`](https://github.com/NixOS/nixpkgs/commit/c50a069e69e597f3989fa8f1cf6e41998b271650) | `latte-dock: fix autostart file (#140462)`                                        |
| [`3109ff57`](https://github.com/NixOS/nixpkgs/commit/3109ff5765505dbe1f7f2905ed3f54c62bd0acaa) | `treewide: avoid use of lib.optional with list in inputs`                         |
| [`c8352c07`](https://github.com/NixOS/nixpkgs/commit/c8352c076d58731627feb972343601c6c646d9d7) | `pamixer: unstable-2021-03-29 -> 1.5`                                             |
| [`18fd76f7`](https://github.com/NixOS/nixpkgs/commit/18fd76f7c77742268ce1840c237a901df3a75c0e) | `pamixer: install using Makefile`                                                 |
| [`ccdde0a8`](https://github.com/NixOS/nixpkgs/commit/ccdde0a882e026a15a5142727bcdf2c95e4b68f2) | `containerd_1_4: 1.4.9 -> 1.4.11`                                                 |
| [`aabceb85`](https://github.com/NixOS/nixpkgs/commit/aabceb8539b694e8711b8632c18f21396aa6f34e) | `containerd: 1.5.5 -> 1.5.7`                                                      |
| [`6b3c9e14`](https://github.com/NixOS/nixpkgs/commit/6b3c9e1400b737ef8e7d1eb4143de11323dec229) | `vscode-extensions.takayama.vscode-qq: init at 1.4.0`                             |
| [`273251e5`](https://github.com/NixOS/nixpkgs/commit/273251e5930ab072c8105c01233550e3ffcc629f) | `dyff: init at 1.4.3 (#134772)`                                                   |
| [`fdcd3a10`](https://github.com/NixOS/nixpkgs/commit/fdcd3a108465d353c815d58519353bd22cb234a9) | `python3Packages.pep8-naming: remove unused input`                                |
| [`12795e3a`](https://github.com/NixOS/nixpkgs/commit/12795e3a53ce38cc0e36b293d26a0779978bf8d2) | `gonic: 0.13.1 -> 0.14.0`                                                         |
| [`e22edea5`](https://github.com/NixOS/nixpkgs/commit/e22edea5545a1ec7a1caecae6d92bf5fe009caea) | `k0sctl: 0.10.2 -> 0.10.3`                                                        |
| [`38644421`](https://github.com/NixOS/nixpkgs/commit/38644421367253ce1aa40c052d9d7f38b0f6de05) | `lua-packages: fix getLuaPath and getLuaCPath`                                    |
| [`369dde88`](https://github.com/NixOS/nixpkgs/commit/369dde88d4e1caaed24da16511b3b4b3fbfbff68) | `open-vm-tools: 11.3.0 -> 11.3.5`                                                 |
| [`14aef06d`](https://github.com/NixOS/nixpkgs/commit/14aef06d9b3ad1d07626bdbb16083b83f92dc6c1) | `velero: 1.6.3 -> 1.7.0 (#140434)`                                                |
| [`b9af3448`](https://github.com/NixOS/nixpkgs/commit/b9af3448c1923e9ed459a9535ff893bea503f085) | `typos: init at 1.1.9 (#140458)`                                                  |
| [`3009b7e5`](https://github.com/NixOS/nixpkgs/commit/3009b7e500faf8b61a30b258ae8e98a0c684f035) | `mhost: init at 0.3.0 (#140455)`                                                  |
| [`ec5455fc`](https://github.com/NixOS/nixpkgs/commit/ec5455fc231160d54b431295e3d0d8b882108dee) | `cmake-language-server: 0.1.2 → 0.1.3`                                            |
| [`6d7c2d3d`](https://github.com/NixOS/nixpkgs/commit/6d7c2d3db3cb4953eb62dccecfe2884f8b18130e) | `pythonPackages.pygls: 0.9.1 → 0.11.2`                                            |
| [`249952c4`](https://github.com/NixOS/nixpkgs/commit/249952c49dfe8237b9501ee07903866acfcb9c19) | `python38Packages.pontos: 21.9.1 -> 21.10.0`                                      |
| [`6c814d55`](https://github.com/NixOS/nixpkgs/commit/6c814d55b2014100e061d0fae847eb9fd4db4421) | `materia-kde-theme: 20210624 -> 20210814`                                         |
| [`2ddc335e`](https://github.com/NixOS/nixpkgs/commit/2ddc335e6f32b875e14ad9610101325b306a0add) | `nixos/doc: clean up defaults and examples`                                       |
| [`cd2e9e83`](https://github.com/NixOS/nixpkgs/commit/cd2e9e83e987cce308a76b8e00ccc8d785eca8c5) | `python3Packages.aioesphomeapi: 9.1.2 -> 9.1.4`                                   |
| [`4f762132`](https://github.com/NixOS/nixpkgs/commit/4f762132b048c93605cf24ca51975cfba7245b0b) | `coqPackages.multinomials: fix`                                                   |
| [`3465a9b5`](https://github.com/NixOS/nixpkgs/commit/3465a9b5d2b1cb195fca375849d8ead36977b1e8) | `yascreen: init at 1.86`                                                          |
| [`8467f290`](https://github.com/NixOS/nixpkgs/commit/8467f29068956b7b10d9a6174089295b60e5a704) | `python3Packages.distorm3: enable tests`                                          |
| [`afc60010`](https://github.com/NixOS/nixpkgs/commit/afc60010a65e2f4ee19fba928acd1bb0ba76128e) | `terraform-providers.netlify: 0.4.0 -> 0.6.12`                                    |
| [`0063d3d6`](https://github.com/NixOS/nixpkgs/commit/0063d3d668cf93fcdefa7f4b4778ddc59d588443) | `python3Packages.distorm3: 3.3.4 -> 3.5.2`                                        |
| [`a89400db`](https://github.com/NixOS/nixpkgs/commit/a89400db621a2d657c2adf2dc024065915996250) | `carla: fix --app-name for compatibility with NSM`                                |
| [`22807730`](https://github.com/NixOS/nixpkgs/commit/228077302ca9cb2f909ffb2f4886385c0343baf7) | `certgraph: init at 20210224`                                                     |
| [`a0306e77`](https://github.com/NixOS/nixpkgs/commit/a0306e7768e470f9ac1525a6df7805e4e4d8e847) | `dismap: init at 0.2`                                                             |
| [`6c5d4a6e`](https://github.com/NixOS/nixpkgs/commit/6c5d4a6e116fa57903c55a38838e9c8aefd62d15) | `dbeaver: 21.2.1 -> 21.2.2`                                                       |
| [`f18bd6f9`](https://github.com/NixOS/nixpkgs/commit/f18bd6f9192e0f4b78419efe4caaf0fd37a0a346) | `gitlab-runner: 14.3.0 -> 14.3.2`                                                 |
| [`ffab7bf0`](https://github.com/NixOS/nixpkgs/commit/ffab7bf0f51bbe2dd84f277983041a2dc29e93f6) | `gitlab: 14.3.1 -> 14.3.2`                                                        |
| [`3f3dc884`](https://github.com/NixOS/nixpkgs/commit/3f3dc884fb7afa44da6b21fe4c66c3836177d1c4) | `cariddi: init at 1.1`                                                            |
| [`b88560c0`](https://github.com/NixOS/nixpkgs/commit/b88560c0a6f930df67be368595c3ba2dc2a54a2f) | `shellz: init at 1.6.0`                                                           |
| [`e74fc39e`](https://github.com/NixOS/nixpkgs/commit/e74fc39e6e9081628d99e8578a59e7fca13fe799) | `mathpix-snipping-tool: 03.00.0050 -> 03.00.0072`                                 |
| [`00c5aa27`](https://github.com/NixOS/nixpkgs/commit/00c5aa27ba8643fc8cecf937a78085ed1f4a9a7f) | `crow-translate: 2.8.4 → 2.8.7`                                                   |
| [`a867c65d`](https://github.com/NixOS/nixpkgs/commit/a867c65d399a48db858656d918d717a2487aa942) | `chia: 1.2.7 -> 1.2.9`                                                            |
| [`2803b689`](https://github.com/NixOS/nixpkgs/commit/2803b68946db1775a56bde197d870d2a7a2a7bb5) | `python3Packages.whirlpool-sixth-sense: init at unstable-2021-08-22`              |
| [`d6db403f`](https://github.com/NixOS/nixpkgs/commit/d6db403f9eb6e2608b6c24de8b8eb89c6d6903e6) | `python3Packages.pyflume: 0.7.0 -> 0.7.1`                                         |
| [`5b3750ed`](https://github.com/NixOS/nixpkgs/commit/5b3750eddf86913d944224ada71ecc5069aca4e8) | `cudatext: 1.143.0 → 1.146.0`                                                     |
| [`793bb4bd`](https://github.com/NixOS/nixpkgs/commit/793bb4bd7af9949f9729d277c9bb2a176159b650) | `python3Packages.asyncwhois: 0.3.2 -> 0.4.0`                                      |
| [`9b60174d`](https://github.com/NixOS/nixpkgs/commit/9b60174db20eadfaa1926c1eb048fa6ad78c14cd) | `python3Packages.whodap: init at 0.1.2`                                           |
| [`6124300b`](https://github.com/NixOS/nixpkgs/commit/6124300ba0da1a72ff1476b6dec21db375bddffa) | `python38Packages.gdown: 3.14.0 -> 4.0.1`                                         |
| [`5487d816`](https://github.com/NixOS/nixpkgs/commit/5487d816c33807920689dfbc8c630f0815869092) | `sad: 0.4.14 -> 0.4.17`                                                           |
| [`63b5af62`](https://github.com/NixOS/nixpkgs/commit/63b5af623aeceaeb7fc18ba6c1f8bd1b0e9284c2) | `eudev: fix homepage link`                                                        |
| [`19ee8600`](https://github.com/NixOS/nixpkgs/commit/19ee8600029c4810e5cc3b921b244109053833f1) | `calibre-web: allow later unidecode release`                                      |
| [`6d298ca4`](https://github.com/NixOS/nixpkgs/commit/6d298ca46b2dbcfc04a7f56448a1151ca55b82f1) | `octoprint: update override for unidecode`                                        |
| [`c59947fd`](https://github.com/NixOS/nixpkgs/commit/c59947fdd16b526b3e7303e86afd30af254e440d) | `python3Packages.unidecode: enable tests`                                         |
| [`79d7190c`](https://github.com/NixOS/nixpkgs/commit/79d7190c19b89661060102f7f2469b23cc1d46b5) | `python3Packages.unidecode: 1.2.0 -> 1.3.1`                                       |
| [`4b866da2`](https://github.com/NixOS/nixpkgs/commit/4b866da20b8a43764d46280dec118b6c13af198a) | `pjsip: 2.10 -> 2.11.1`                                                           |
| [`d8e6e07a`](https://github.com/NixOS/nixpkgs/commit/d8e6e07af0a28f5b7564076dfed977dd31ce2d02) | `r-httpuv: add missing zlib.dev dependency to fix the build`                      |
| [`2489084b`](https://github.com/NixOS/nixpkgs/commit/2489084b0592b7ffc8744e8235b008f48f6b1fad) | `krane: init at 2.3.0`                                                            |
| [`dd74170c`](https://github.com/NixOS/nixpkgs/commit/dd74170ce49788447f34fbe9a63972735ecb7d4b) | `flex-ndax: init at 0.1-20210714.0`                                               |
| [`849f091e`](https://github.com/NixOS/nixpkgs/commit/849f091e68efd6d0e29e0b93decad57732911782) | `flex-ncat: init at 0.0-20210420.0`                                               |
| [`396e421c`](https://github.com/NixOS/nixpkgs/commit/396e421c8967175b476a79e727c6c607999ff62c) | `rancher: init at 2.4.13`                                                         |
| [`95c8ba90`](https://github.com/NixOS/nixpkgs/commit/95c8ba90a44de597fbb62838a69a7d61f6e8f0c2) | `pgo-client: 4.7.2 -> 4.7.3`                                                      |
| [`6ea41eaa`](https://github.com/NixOS/nixpkgs/commit/6ea41eaabb48dd8401d0d30b85fb7004a615a320) | `redis: 6.2.5 -> 6.2.6`                                                           |
| [`1c0a20ef`](https://github.com/NixOS/nixpkgs/commit/1c0a20efcfdb40d7a08078e436baade866f83b0f) | `create-amis.sh: fix typo`                                                        |
| [`2d67b946`](https://github.com/NixOS/nixpkgs/commit/2d67b946b7a065dfae76f77e6da810ac022f99bd) | `create-amis.sh: use status message`                                              |
| [`407998d1`](https://github.com/NixOS/nixpkgs/commit/407998d15a06a733c330b0a73e1897032c4e6041) | `create-amis.sh: add support for the ZFS AMIs`                                    |
| [`1ff82fec`](https://github.com/NixOS/nixpkgs/commit/1ff82fec9a0f48ce29b73113b24d43b83e023813) | `create-amis.sh: allow uploading private AMIs`                                    |
| [`0543f2d2`](https://github.com/NixOS/nixpkgs/commit/0543f2d2f62dcc3d5e917f34d3c0526d0548473f) | `create-amis.sh: make vars overridable from env`                                  |
| [`417487b4`](https://github.com/NixOS/nixpkgs/commit/417487b45764cedd6474c7990219b795a42117be) | `cbqn: 0.0.0+unstable=2021-09-29 -> 0.0.0+unstable=2021-10-01`                    |
| [`fc88ec5d`](https://github.com/NixOS/nixpkgs/commit/fc88ec5d9d0ad91a091645655e78f46ac642fb0e) | `dbqn: init at 0.0.0+unstable=2021-10-02`                                         |
| [`e6bdd969`](https://github.com/NixOS/nixpkgs/commit/e6bdd9690ced527fffa7a432ec80135e932907c4) | `wgpu: init at 0.10.0`                                                            |
| [`9e6a39be`](https://github.com/NixOS/nixpkgs/commit/9e6a39be4d465892d32bee6944626415fbd77933) | `perlPackages.LaTeXML: 0.8.5 -> 0.8.6 (#140173)`                                  |
| [`f1f64068`](https://github.com/NixOS/nixpkgs/commit/f1f640684c2e926d187e75f9910bbe04518b35b7) | `rewritefs: add `unstable` prefix`                                                |
| [`3f025a3b`](https://github.com/NixOS/nixpkgs/commit/3f025a3bffb07495f8b7e3f2dd357088f789231e) | `git-extras: 6.2.0 -> 6.3.0`                                                      |
| [`c80fae5b`](https://github.com/NixOS/nixpkgs/commit/c80fae5bbeb9f4bcc0c48a1acd3bc8b4a12d7438) | `gitlab: 14.2.4 -> 14.3.1`                                                        |
| [`7d88d0b0`](https://github.com/NixOS/nixpkgs/commit/7d88d0b040c23684815b2b0e7eb742bcfc3cd88b) | `clair: 4.2.0 -> 4.3.0`                                                           |
| [`966763c5`](https://github.com/NixOS/nixpkgs/commit/966763c5b17e46bc1128bd9c4c1a8bde9a762dd2) | `btop: 1.0.10 -> 1.0.13`                                                          |
| [`236d58ae`](https://github.com/NixOS/nixpkgs/commit/236d58aeefd5ad0b80b86ae996906f6dfaaee766) | `vimPlugins.neuron-nvim: init at 2021-03-20`                                      |
| [`9336af2d`](https://github.com/NixOS/nixpkgs/commit/9336af2d1aa19247c9309227699ba1867b65e38b) | `fnlfmt: 0.2.1 -> 0.2.2 (#140381)`                                                |
| [`be01e0f3`](https://github.com/NixOS/nixpkgs/commit/be01e0f3bc8f11fffb4394caeab806350a2536ca) | `black: Disable failing tests on Darwin (#130785)`                                |
| [`c4115245`](https://github.com/NixOS/nixpkgs/commit/c41152455777f877d5488236616890980fe7457c) | `vimPlugins: update`                                                              |
| [`752336b6`](https://github.com/NixOS/nixpkgs/commit/752336b6e82349db3cf8a9a497101d12fc9ec2f8) | `home-assistant: update component-packages`                                       |
| [`921142e8`](https://github.com/NixOS/nixpkgs/commit/921142e8897b8db93f751149dccc2a577764cacb) | `python3Packages.pycarwings2: init at 2.11`                                       |
| [`f887d5b3`](https://github.com/NixOS/nixpkgs/commit/f887d5b363b75456d787e2a7e4ca71d2371b22d8) | `maintainers/maintainers-list: add Matrix IDs`                                    |
| [`0d7d78f8`](https://github.com/NixOS/nixpkgs/commit/0d7d78f8ff9539fbaf54ef8fc972eb4336893b87) | `python3Packages.async-upnp-client: 0.22.4 -> 0.22.5`                             |
| [`97fe835b`](https://github.com/NixOS/nixpkgs/commit/97fe835b44f6f3fe020db6e9a372a904750cc29f) | `coqPackages.gappalib: 1.4.5 → 1.5.0`                                             |
| [`f8333515`](https://github.com/NixOS/nixpkgs/commit/f83335157c800af78709ad6b13925572d15accb7) | `electron_15: init at 15.1.0`                                                     |
| [`6749fd84`](https://github.com/NixOS/nixpkgs/commit/6749fd84fa6c888ce7618368b1782b666b608e5c) | `cawbird: add own API key to not run into rate limits`                            |
| [`a21f4b7a`](https://github.com/NixOS/nixpkgs/commit/a21f4b7a76d1984d10cce20ef02076710155a0d4) | `iosevka: 10.0.0 → 10.3.1`                                                        |
| [`27c05093`](https://github.com/NixOS/nixpkgs/commit/27c05093234894f3eb98e05f41ea37073a5cdfe9) | `webcat: init at unstable-2021-09-06`                                             |
| [`d5735ae1`](https://github.com/NixOS/nixpkgs/commit/d5735ae18defec17313b82d8002b99ca40dd314e) | `erigon: 2021.09.02 -> 2021.09.04 (#139646)`                                      |
| [`52be208f`](https://github.com/NixOS/nixpkgs/commit/52be208f205b3e4ae40f1ce912c29d9db1273c65) | `python3Packages.toposort: 1.6 -> 1.7`                                            |
| [`6d8cab0b`](https://github.com/NixOS/nixpkgs/commit/6d8cab0b537bf768d044f1789a868261f45803fe) | `waydroid: Init at 1.1.1`                                                         |
| [`7f9f26f9`](https://github.com/NixOS/nixpkgs/commit/7f9f26f942f651111cc3472b1fe35a8e3ec1a174) | `python3Packages.gbinder-python: Init at 1.0.0`                                   |
| [`0aeb28e5`](https://github.com/NixOS/nixpkgs/commit/0aeb28e566eddfca126f19cec70eb12bca4771d1) | `libgbinder: Init at 1.1.12`                                                      |
| [`5667c1fc`](https://github.com/NixOS/nixpkgs/commit/5667c1fc3f1235e4a55a283d76cfed0ee3cfb04f) | `libglibutil: Init at 1.0.55`                                                     |
| [`6c07b4a3`](https://github.com/NixOS/nixpkgs/commit/6c07b4a3f8d803f78d76d19126f5d0340205327a) | `python3Packages.rapidfuzz: 1.7.0 -> 1.7.1`                                       |
| [`0cb3c776`](https://github.com/NixOS/nixpkgs/commit/0cb3c776cf796c27d535a28b7e0592a05b101e48) | `pulumi-bin: 3.12.0 -> 3.13.2`                                                    |
| [`fecc5d7b`](https://github.com/NixOS/nixpkgs/commit/fecc5d7bfff23a211278cb1e1fc2a9c2dbfb43ea) | `treewide: pkgs/**.nix: remove trailing whitespaces`                              |
| [`b7cec1d2`](https://github.com/NixOS/nixpkgs/commit/b7cec1d27d7aee0a22d7a8a52a7f0b72b50f832e) | `selene: init at 0.14.0`                                                          |
| [`a0f20138`](https://github.com/NixOS/nixpkgs/commit/a0f20138a4323764ead04e7ffda25dbc15dd81c6) | `gnomeExtensions.unite: remove manually packaging and use extension overrides`    |
| [`ebebfb4b`](https://github.com/NixOS/nixpkgs/commit/ebebfb4bf0ec3ef0590021cdf598cb0c110b74d9) | `gobang: fix darwin build`                                                        |
| [`785d49fb`](https://github.com/NixOS/nixpkgs/commit/785d49fb982cc2e9d579f8fffa4f848ea5336679) | `rewritefs: 2020-02-21 -> 2021-10-03`                                             |
| [`8067021e`](https://github.com/NixOS/nixpkgs/commit/8067021ee7c637cae2d7597f64e7436e803b0b04) | `chezmoi: 2.1.6 -> 2.3.0`                                                         |
| [`5d572155`](https://github.com/NixOS/nixpkgs/commit/5d572155d472aa2129736ddd4cba29f8bd2b083d) | `python3Packages.gios: 2.0.0 -> 2.1.0`                                            |
| [`d7442dc6`](https://github.com/NixOS/nixpkgs/commit/d7442dc613f8ba6d105b46b845dddbb2fc350b19) | `ocamlPackages.merlin: 4.1 → 4.3.1`                                               |
| [`ba1029a8`](https://github.com/NixOS/nixpkgs/commit/ba1029a81a9e3e56909fb660c721a7357b4905c8) | `Submit/fix vega lite (#139876)`                                                  |
| [`9a8c64a2`](https://github.com/NixOS/nixpkgs/commit/9a8c64a2f608c305b38137f793afc1e7865a00c3) | `rslint: init at 0.3.0`                                                           |
| [`330b1e08`](https://github.com/NixOS/nixpkgs/commit/330b1e08b8df4e1f0100a0a7810ec3157749e5ee) | `nixos/lib/make-options-doc: implement literalDocBook`                            |
| [`404ece99`](https://github.com/NixOS/nixpkgs/commit/404ece99f21859dd973c4e2693d25c9fa339d836) | `asciinema: 2.0.2 -> 2.1.0`                                                       |
| [`32fb71f2`](https://github.com/NixOS/nixpkgs/commit/32fb71f2d9464452038354ee637ebed6017b8225) | `python38Packages.sagemaker: 2.59.4 -> 2.59.6`                                    |
| [`a446cbaa`](https://github.com/NixOS/nixpkgs/commit/a446cbaaaa4b7888558a88910cec70a722e8e97c) | `lscolors: 0.7.1 -> 0.8.0`                                                        |
| [`5313fd63`](https://github.com/NixOS/nixpkgs/commit/5313fd63d3ceeadf3afefbe74a193943025400d8) | `lwan: 0.3 -> 0.4`                                                                |
| [`52a2e413`](https://github.com/NixOS/nixpkgs/commit/52a2e4136e270f9efd6838adb69304fe6d4d431e) | `lib/options: add literalExpression and literalDocBook, deprecate literalExample` |
| [`c7fc01cd`](https://github.com/NixOS/nixpkgs/commit/c7fc01cd77b4b45ae469f3aac25496384c527861) | `aerospike: drop blanket -Werror (#140306)`                                       |
| [`a573c35b`](https://github.com/NixOS/nixpkgs/commit/a573c35b3adc639bddf701ec80cd6d3d9284baff) | `ocrmypdf: 12.5.0 -> 12.6.0`                                                      |
| [`5895ece3`](https://github.com/NixOS/nixpkgs/commit/5895ece3b943092ce2a73b396bf607a0af39e8ee) | `mopidy-youtube: 3.2 -> 3.4`                                                      |
| [`770cdc38`](https://github.com/NixOS/nixpkgs/commit/770cdc3897da0f2f183d431d4286dcf6f193ab5b) | `python38Packages.python-osc: 1.7.7 -> 1.8.0`                                     |
| [`0d1421c5`](https://github.com/NixOS/nixpkgs/commit/0d1421c5c5fc0c51ec5033c8e8303d4b04e65d5c) | `exploitdb: 2021-09-30 -> 2021-10-02`                                             |