### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0699530f08290f34c532beedd66046825d9756fa",
-        "sha256": "1845czci6i1jj85mpr2yjvxr8kr9nqmlpimggfb6zxndzyb5n8zx",
+        "rev": "f91fec348dd7e6da0bb222c9470c7d1046dcec78",
+        "sha256": "0kl6cz81z0jc6kzpwlbn4r2dpn25sfdvq3jykhbrbx43l4hxkz1k",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0699530f08290f34c532beedd66046825d9756fa.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f91fec348dd7e6da0bb222c9470c7d1046dcec78.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`0afbd8c8`](https://github.com/NixOS/nixpkgs/commit/0afbd8c8a8db3c1238b422bbc7ed08d877eb4867) | `git-cliff: 0.3.0 -> 0.4.0`                                            |
| [`9f4ccabc`](https://github.com/NixOS/nixpkgs/commit/9f4ccabc7ebcb36204058c53449effeba4818cbf) | `coqPackages.Verdi: 20200131 → 20210524`                               |
| [`05845bd4`](https://github.com/NixOS/nixpkgs/commit/05845bd4295c1feae7f1dd2d055dc124881ea6e0) | `coqPackages.StructTact: 20181102 → 20210328`                          |
| [`8cc0385c`](https://github.com/NixOS/nixpkgs/commit/8cc0385c8b1b4d854a0cf8e45450a39774c43175) | `orpie: fix build`                                                     |
| [`8f7589ff`](https://github.com/NixOS/nixpkgs/commit/8f7589ff3fdd6e3fadda5608905d838838a707d1) | `python38Packages.langcodes: 3.1.0 -> 3.2.0`                           |
| [`372c4c72`](https://github.com/NixOS/nixpkgs/commit/372c4c7276ac4c896ad1c429602f3fe237d3a7ec) | `python38Packages.bugsnag: 4.1.0 -> 4.1.1`                             |
| [`dc5bfd22`](https://github.com/NixOS/nixpkgs/commit/dc5bfd2271f3390ca20109ac04415f0fa0b9449d) | `python38Packages.google-cloud-access-context-manager: 0.1.7 -> 0.1.8` |
| [`d8ceddad`](https://github.com/NixOS/nixpkgs/commit/d8ceddad117e71d85b61a1b853ac28510de9e06e) | `python38Packages.django-webpack-loader: 1.1.0 -> 1.4.1`               |
| [`3f46ed74`](https://github.com/NixOS/nixpkgs/commit/3f46ed7457b3367e5bf215adb9f59a52315e4dbc) | `htop: set sysconfdir to /etc`                                         |
| [`a425421e`](https://github.com/NixOS/nixpkgs/commit/a425421e28e3a482db3730aa673ad82f6f0eb75c) | `nixos/htop: add module`                                               |
| [`561f938f`](https://github.com/NixOS/nixpkgs/commit/561f938ff1bac78fe1fdcee49672ef89d068dee2) | `bigloo: explicitly depend on unistring on darwin (#140521)`           |
| [`e49c9fe1`](https://github.com/NixOS/nixpkgs/commit/e49c9fe1c0d95a00c43a837934e0bf499e3ae784) | `erlang-ls: 0.19.0 -> 0.20.0`                                          |
| [`4769e66c`](https://github.com/NixOS/nixpkgs/commit/4769e66c3d03cf8e7de80c3c70398389d3d2bf86) | `haskellPackages.hakyll-images: assert dontCheck is still necessary`   |
| [`1b805989`](https://github.com/NixOS/nixpkgs/commit/1b80598997fbad2f74c972985b83a7171451eff6) | `rclone: 1.56.1 -> 1.56.2`                                             |
| [`d189bf92`](https://github.com/NixOS/nixpkgs/commit/d189bf92f9be23f9b0f6c444f6ae29351bb7125c) | `linuxPackages.system76: 1.0.12 -> 1.0.13`                             |
| [`408bf549`](https://github.com/NixOS/nixpkgs/commit/408bf549cf4136ac4f34e5a0433ac5de86805247) | `linuxPackages.system76-power: 1.1.17 -> 1.1.18`                       |
| [`bdcc25f2`](https://github.com/NixOS/nixpkgs/commit/bdcc25f2f5dc8c71ff2f35f6f2377149523d5ca6) | `linuxPackages.hid-nintendo: 3.1 -> 3.2`                               |
| [`04efd289`](https://github.com/NixOS/nixpkgs/commit/04efd2898bff228bedbb3f57faba500ad8263e71) | `python3Packages.yeelight: 0.7.5 -> 0.7.6`                             |
| [`e6016fe9`](https://github.com/NixOS/nixpkgs/commit/e6016fe9513d8bdab83bbb1b5ca2c293fc4394d9) | `lnd: 0.13.1-beta -> 0.13.3-beta`                                      |
| [`c077f5ae`](https://github.com/NixOS/nixpkgs/commit/c077f5ae57aba01cc4cfac85c9500d5e7c432ded) | `haskell-language-server: Remove useless major version aliases`        |
| [`144058e1`](https://github.com/NixOS/nixpkgs/commit/144058e16d94268b1be8849421cb68420f2a0996) | `docker: 20.10.8 -> 20.10.9`                                           |
| [`25da0b3b`](https://github.com/NixOS/nixpkgs/commit/25da0b3bbbeb703285a493c0773dcccf3d46009b) | `nixUnstable: 2.4pre20210922 -> 2.4pre20211001`                        |
| [`6ea6a232`](https://github.com/NixOS/nixpkgs/commit/6ea6a232cc62269866b5690094015fcab2184e18) | `lowdown: 0.8.6 -> 0.9.0`                                              |
| [`2e3b19b8`](https://github.com/NixOS/nixpkgs/commit/2e3b19b81d46ae9748d9d936c252e6e88c3157fb) | `wgpu: rename to wgpu-utils, use upstream tag`                         |
| [`80488223`](https://github.com/NixOS/nixpkgs/commit/804882231632fd3919ef997c904b2a3646ae5187) | `consul: 1.10.2 -> 1.10.3`                                             |
| [`901a86ce`](https://github.com/NixOS/nixpkgs/commit/901a86ce95c1b90265fb3d15fa8c3a81b25976f1) | `ghost: init at 8.0.0`                                                 |
| [`e35daf79`](https://github.com/NixOS/nixpkgs/commit/e35daf79a68b813b387a8197402fa4e2bb7c5a7d) | `apkleaks: init at 2.6.1`                                              |
| [`00627e0c`](https://github.com/NixOS/nixpkgs/commit/00627e0ce3ffd67fecd040632d8efdbadb41fcbb) | `haskellPackages.hakyll-images: disable broken test suite`             |
| [`8d1e2a10`](https://github.com/NixOS/nixpkgs/commit/8d1e2a10ce89abb71588937778d49169eb6b0ac3) | `haskellPackages.hakyll-filestore: unbreak using jailbreak`            |
| [`72a54a70`](https://github.com/NixOS/nixpkgs/commit/72a54a702159ea6d95a7139a3ad846a567baeabf) | `haskellPackages.http3: build with network 3.1.2.2`                    |
| [`82117bcb`](https://github.com/NixOS/nixpkgs/commit/82117bcbd5a01a9621068cd2c42595af02494e41) | `chezmoi: 2.3.0 -> 2.6.1`                                              |
| [`e52f71b2`](https://github.com/NixOS/nixpkgs/commit/e52f71b28e82fddd3540216be3ec63a629da3196) | `python38Packages.systembridge: 2.1.0 -> 2.1.3`                        |
| [`7d77818c`](https://github.com/NixOS/nixpkgs/commit/7d77818c9eade1fccb33901eef06f8b2e624086f) | `haskellPackages.ghcup: assert that preCheck is still needed`          |
| [`2db37a40`](https://github.com/NixOS/nixpkgs/commit/2db37a400efa0965e191db04559325c645b1cacd) | `haskellPackages: regenerate package set based on current config`      |
| [`a5c8b9f1`](https://github.com/NixOS/nixpkgs/commit/a5c8b9f166ede76ea580457d3f0404da3cbc426d) | `all-cabal-hashes: 2021-10-01T17:27:40Z -> 2021-10-02T21:03:40Z`       |
| [`2eab4d5c`](https://github.com/NixOS/nixpkgs/commit/2eab4d5c0839ef44e1d85612b5a433a0c849462c) | `haskellPackages.hashes: fix build on non-x86`                         |
| [`8da4d55f`](https://github.com/NixOS/nixpkgs/commit/8da4d55f72da2272aabfdf073464815480389185) | `haskellPackages.ghcup: fix build by providing up to date deps`        |
| [`2dee7c52`](https://github.com/NixOS/nixpkgs/commit/2dee7c529f99a2ee30ff7dd4886a9c40ea9824ed) | `haskellPackages.candid: clean up obsolete override`                   |
| [`10834782`](https://github.com/NixOS/nixpkgs/commit/10834782e2dfd9f01c1329cfaa3fb31b88cd5e4e) | `haskellPackages: regenerate package set based on current config`      |
| [`d3f87c81`](https://github.com/NixOS/nixpkgs/commit/d3f87c81cb92a431f14a19b7641ddca2fe9edf3e) | `all-cabal-hashes: 2021-09-29T20:58:23Z -> 2021-10-01T17:27:40Z`       |
| [`4990b7f8`](https://github.com/NixOS/nixpkgs/commit/4990b7f876fd4012897c2307b251dc04de24a092) | `ubootOrangePiZero2: init`                                             |
| [`25a4ef90`](https://github.com/NixOS/nixpkgs/commit/25a4ef905f3f8cebf6b5780376ede454403eddef) | `armTrustedFirmwareAllwinnerH616: init`                                |