### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40f95ae12ac630b76e8f4aa2d378fd2f2a959ff5",
-        "sha256": "058rsw5fdk90bnl51b40lfnsl9w104gxplpyww7n3gjxp8w9frh9",
+        "rev": "ea4524e6cc7761c3cc271233fa97b5e7473f760a",
+        "sha256": "1an68i4hlk1hyds9y6n513kybrk8gsgcp81frs4x3a726ls1hrwj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/40f95ae12ac630b76e8f4aa2d378fd2f2a959ff5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ea4524e6cc7761c3cc271233fa97b5e7473f760a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`ea4524e6`](https://github.com/NixOS/nixpkgs/commit/ea4524e6cc7761c3cc271233fa97b5e7473f760a) | `jd-diff-patch: init at 1.4.0`                                             |
| [`5627b8ae`](https://github.com/NixOS/nixpkgs/commit/5627b8ae5b927351693f27e96738b7787567d606) | `cbqn: 2021-10-01 -> 2021-10-05 (#140795)`                                 |
| [`a961352f`](https://github.com/NixOS/nixpkgs/commit/a961352f5ebc021129ce529fda52968b0b0eb158) | `linux-testing-bcachefs: Add note about keeping bcachefs-tools up to date` |
| [`6eb75312`](https://github.com/NixOS/nixpkgs/commit/6eb75312553092f4b0b1a7a98868c7303dfe2125) | `bcachefs-tools: 2021-07-08 -> 2021-10-01`                                 |
| [`dffd972a`](https://github.com/NixOS/nixpkgs/commit/dffd972ab417c182dcad9524acfcf6f2a72160b9) | `ser2net: 4.3.3 -> 4.3.4`                                                  |
| [`811f8499`](https://github.com/NixOS/nixpkgs/commit/811f849961b7e0abe45daa291aadd884fac3bb18) | `buildRustCrate: Don't override the linker during cross`                   |
| [`44307611`](https://github.com/NixOS/nixpkgs/commit/443076118675ef83ef0db0938fb249273170fc56) | `buildRustCrate: Add `extraRustcOptsForBuild``                             |
| [`0ee5640d`](https://github.com/NixOS/nixpkgs/commit/0ee5640d78f53c2b912accf7573fb628224feca3) | `buildRustCrate: Fix extra cross args`                                     |
| [`d25fa35e`](https://github.com/NixOS/nixpkgs/commit/d25fa35e0211c91ebe5942fb070ca9dabc72d150) | `haskellPackages.hercules-ci-agent: Re-enable profiling`                   |
| [`cc3f2432`](https://github.com/NixOS/nixpkgs/commit/cc3f2432d0d05ed12ef8b9858c54048edadbccbb) | `nixos/nix-daemon: Add enable option`                                      |
| [`50db7e49`](https://github.com/NixOS/nixpkgs/commit/50db7e49ed64a7c22d853512844be49aa1bada23) | `python38Packages.urlextract: 1.3.0 -> 1.4.0`                              |
| [`1fd150bf`](https://github.com/NixOS/nixpkgs/commit/1fd150bf62b923cd55abe00a5f740b547e4fb490) | `vsh: 0.12.0 -> 0.12.1`                                                    |
| [`2924140f`](https://github.com/NixOS/nixpkgs/commit/2924140fac5b61f56e040b350fa3396a0e0918e3) | `dbqn, dbqn-native: 2021-10-02 -> 2021-10-05  (#140601)`                   |
| [`bc9b01fa`](https://github.com/NixOS/nixpkgs/commit/bc9b01fadda2bbcdfbffcb07273a0138a6f2c832) | `k3s: updateScript updated`                                                |
| [`7ef6135e`](https://github.com/NixOS/nixpkgs/commit/7ef6135ef2126e7d1e1575db5feedf7626149065) | `python38Packages.pypinyin: 0.42.0 -> 0.43.0`                              |
| [`6bd8854e`](https://github.com/NixOS/nixpkgs/commit/6bd8854e3cc576d79ee91a6a96cd960457354cb4) | `sbcl: fix the 2.0.8 version`                                              |
| [`b9bc0b94`](https://github.com/NixOS/nixpkgs/commit/b9bc0b9480b619d3d41cd0ad38d0850ccd3294ae) | `signal-desktop: 5.18.1 -> 5.19.0`                                         |
| [`8e7098b6`](https://github.com/NixOS/nixpkgs/commit/8e7098b6671284394b48e03cc241fcb48769f426) | `python3Packages.Theano: fix meta.homepage`                                |
| [`8dab1140`](https://github.com/NixOS/nixpkgs/commit/8dab11404e50f48e303434b4923d086d165d0481) | `python3Packages.ocrmypdf: fix hash`                                       |
| [`2faec19c`](https://github.com/NixOS/nixpkgs/commit/2faec19ccb5b7655c645dcb048ef1384c64230b0) | `exploitdb: 2021-10-02 -> 2021-10-06`                                      |
| [`f7852b6d`](https://github.com/NixOS/nixpkgs/commit/f7852b6d583eb2f4752d15a9ed8eb76e3f64d71d) | `python38Packages.pypinyin: 0.42.0 -> 0.43.0`                              |
| [`aac55f4e`](https://github.com/NixOS/nixpkgs/commit/aac55f4ea27c0e21081c351e22525d5b5c523f83) | `foxdot: add foxdot application alias`                                     |
| [`0c2adb9a`](https://github.com/NixOS/nixpkgs/commit/0c2adb9a56419e1dc7952ffff873c21dac6e7150) | `python38Packages.transitions: 0.8.9 -> 0.8.10`                            |
| [`170fda82`](https://github.com/NixOS/nixpkgs/commit/170fda826d5e9ba0054cfd54a45a1834b01d0379) | `python3Packages.graspologic: update homepage`                             |
| [`edbb1c61`](https://github.com/NixOS/nixpkgs/commit/edbb1c61a747ca8e7836c5c3318f74bb2cf69fef) | `rslint: 0.3.0 -> 0.3.1`                                                   |
| [`b09e71b5`](https://github.com/NixOS/nixpkgs/commit/b09e71b5492245192f50839f6ebad60dc4037bd5) | `vimPlugins: update`                                                       |
| [`864f7f87`](https://github.com/NixOS/nixpkgs/commit/864f7f87ccf2c415e1e496258af5d5d75e009db9) | `python38Packages.mypy-boto3-s3: 1.18.54 -> 1.18.55`                       |
| [`ac53325c`](https://github.com/NixOS/nixpkgs/commit/ac53325cfba03cde392d435937bb554b142e7223) | `python3Packages.pyefergy: init at 0.1.0`                                  |
| [`d96e1663`](https://github.com/NixOS/nixpkgs/commit/d96e16638f0bcf40e1bee01112f7370dd64e5271) | `python3Packages.iso4217: init at 1.6`                                     |
| [`1929ba16`](https://github.com/NixOS/nixpkgs/commit/1929ba16250ae5ce7b894a8a98a682a4b07d8ffa) | `agdaPackages.agda-prelude: compat-2.6.1 -> compat-2.6.2`                  |
| [`a0954187`](https://github.com/NixOS/nixpkgs/commit/a09541870f9df3dd450d7f65436407bcd3f2635a) | `vimPlugins.compe-tmux: set branch to cmp`                                 |
| [`7ad2a73c`](https://github.com/NixOS/nixpkgs/commit/7ad2a73cb286223c2f5116f2a728f42aa0467c98) | `foxtrotgps: 1.2.2+329 -> 1.2.2+331`                                       |
| [`e08f5495`](https://github.com/NixOS/nixpkgs/commit/e08f54959964c966b027dbec84dd6e37070988b0) | `marble: fix build with gpsd 3.23.1`                                       |
| [`80546a3f`](https://github.com/NixOS/nixpkgs/commit/80546a3fd1470871bd2c183143d234b52cfc4dd8) | `python3Packages.pikepdf: 3.1.0 -> 3.1.1`                                  |
| [`4662abd3`](https://github.com/NixOS/nixpkgs/commit/4662abd3b4e878437ff762788c7af858e2c03ca8) | `R: don't restrict hydraPlatforms`                                         |
| [`80f76562`](https://github.com/NixOS/nixpkgs/commit/80f7656229efee8817880250b2ca097a69898330) | `calibre-web: 0.6.12 -> 0.6.13`                                            |
| [`2e0f592e`](https://github.com/NixOS/nixpkgs/commit/2e0f592e67528d88f36fa03cdad29f88461ed6a3) | `python38Packages.sqlite-utils: 3.17 -> 3.17.1`                            |
| [`2e5ce893`](https://github.com/NixOS/nixpkgs/commit/2e5ce8930cf14bdfc8c6e524b82eaf15286214b1) | `agdaPackages.agdarsec: Init at 0.4.1`                                     |
| [`58ec6ce9`](https://github.com/NixOS/nixpkgs/commit/58ec6ce9b587c763636ceff916bcd41de87c9748) | `build-support/agda: Make includePaths configurable`                       |
| [`3b1f58cd`](https://github.com/NixOS/nixpkgs/commit/3b1f58cd40d4519d86b25dd28d2d1166ba56c278) | `libnsl: 1.3.0 -> 2.0.0`                                                   |