### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6755a884b24038a73dd4c8022dbb05375feef0a7",
-        "sha256": "1jxc2mmgs8bll8vpzl23ds2ppr4fdza77b1m1748qfi3wv7bs39k",
+        "rev": "9e84e5f8f36ef5320497e79f8aca6e811b066d2f",
+        "sha256": "0qf1227hrn8ddv1ip3mnx8gy2lw3h2ibz82qlr96s5b048x043w9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6755a884b24038a73dd4c8022dbb05375feef0a7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/9e84e5f8f36ef5320497e79f8aca6e811b066d2f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`e4dd32f6`](https://github.com/NixOS/nixpkgs/commit/e4dd32f67e57dfff417678f9a6e018450bdee1c1) | `nixos/v2ray: add an option for specifying v2ray package used in the systemd service`              |
| [`6eb80a29`](https://github.com/NixOS/nixpkgs/commit/6eb80a2990c4717d4183894e42ed58e311fa3a9f) | `firefox-beta-bin: 93.0b9 -> 94.0b2`                                                               |
| [`037aa189`](https://github.com/NixOS/nixpkgs/commit/037aa189a594c27f6948831a0e5c9f70c4190418) | `firefox-devedition-bin: 93.0b9 -> 94.0b2`                                                         |
| [`f7a1df95`](https://github.com/NixOS/nixpkgs/commit/f7a1df955530f4e190db017c242b96d4abddf0a6) | `nix_2_4: init at 2.4pre-rc1`                                                                      |
| [`f4cc15d0`](https://github.com/NixOS/nixpkgs/commit/f4cc15d07212ad122a7da3ba65b035cdfeb40f91) | `nixUnstable: 2.4pre20211106 -> 2.5pre20211107`                                                    |
| [`acb3238f`](https://github.com/NixOS/nixpkgs/commit/acb3238fb61256c6e0fec4c55aff9e71c0b4567e) | `emacs.pkgs.melpa-packages: 2021-10-07`                                                            |
| [`740cdfb3`](https://github.com/NixOS/nixpkgs/commit/740cdfb3d2ac338f99121cd103d1a16ee48368d3) | `emacs.pkgs.elpa-packages: 2021-10-07`                                                             |
| [`9cb5337f`](https://github.com/NixOS/nixpkgs/commit/9cb5337fde7c530df0cfbea514ffb17842501654) | `vim-utils: fix dependency graph (#140118)`                                                        |
| [`d08986bd`](https://github.com/NixOS/nixpkgs/commit/d08986bdaf448e87eb2ce3af6ae9e71a2a777c28) | `prisma-engines: add support for darwin`                                                           |
| [`1b0e567c`](https://github.com/NixOS/nixpkgs/commit/1b0e567cb1a00da398f1605e47d72a540f74b08f) | `rusty-man: init at 0.4.3`                                                                         |
| [`5ed4736b`](https://github.com/NixOS/nixpkgs/commit/5ed4736b27339ed0bafa069f76420a82e78776ef) | `hilbish: fix paths`                                                                               |
| [`eb9c6ed7`](https://github.com/NixOS/nixpkgs/commit/eb9c6ed705cf703836502338cbb0a6092b26a918) | `python3Packages.patrowl4py: init at 1.1.7`                                                        |
| [`e98727a9`](https://github.com/NixOS/nixpkgs/commit/e98727a9162b982fd4f6d4164c0109391ca888ac) | `ntbtls: move with lib to smaller scope`                                                           |
| [`1a534754`](https://github.com/NixOS/nixpkgs/commit/1a534754569d1f7c6f1e2a74f61ada46556d2d4b) | `tor-browser-bundle-bin: 10.5.6 -> 10.5.8`                                                         |
| [`f1265b72`](https://github.com/NixOS/nixpkgs/commit/f1265b72271ef93eb917fcf6b5605fd1f00c0043) | `ligolo-ng: 0.1 -> 0.2`                                                                            |
| [`a4471b7c`](https://github.com/NixOS/nixpkgs/commit/a4471b7cda1546cb1bcb05f7c15b25566cad2cb1) | `pulumi-bin: 3.13.2 -> 3.14.0`                                                                     |
| [`41db5e3b`](https://github.com/NixOS/nixpkgs/commit/41db5e3b41d25157c58e5230906ef819d67e427d) | `python39Packages.pastescript: remove chetaah, add python namespace, add meta.maintainers, format` |
| [`6f9982c2`](https://github.com/NixOS/nixpkgs/commit/6f9982c2d969a585dcebae579210d5792d38f7f2) | `python39Packages.paste: enable tests`                                                             |
| [`e90e3c3b`](https://github.com/NixOS/nixpkgs/commit/e90e3c3bc4cd7511d62e1c87c4c0a0184d59b890) | `python3Packages.pastescript: move to python3Packages`                                             |
| [`76442456`](https://github.com/NixOS/nixpkgs/commit/76442456768656c9c3a269ebeb7a04c40583f763) | `python39Packages.webtest: move contraint patching to postPatch`                                   |
| [`dcc9efa3`](https://github.com/NixOS/nixpkgs/commit/dcc9efa371230a0d1831077a5f8fc086a3065b91) | `python39Packages.sqlobject: add missing meta.maintainers, switch to pytestCheckHook`              |
| [`ec7ec7db`](https://github.com/NixOS/nixpkgs/commit/ec7ec7db7d39dc58afb8463385514c9b7b7a9999) | `python39Packages.pyramid: remove doCheck condition`                                               |
| [`68370cf3`](https://github.com/NixOS/nixpkgs/commit/68370cf310bc18c53631e92d5e3cd77aaba52187) | `python39Packages.plaster-pastedeploy: add meta, switch to pytestCheckHook`                        |
| [`cc96f19e`](https://github.com/NixOS/nixpkgs/commit/cc96f19e0efb90fe88517003bf40280cc15b2d2c) | `libgrss: support cross-compilation`                                                               |
| [`c5fb35d8`](https://github.com/NixOS/nixpkgs/commit/c5fb35d838e3429002f08ede40bd991d97da896a) | `libcanberra: support cross-compilation`                                                           |
| [`8c4233de`](https://github.com/NixOS/nixpkgs/commit/8c4233de8ae3ba7b3eaa02f5fa77e16b1fbd417c) | `starsector: generate desktop file`                                                                |
| [`8fc6a95b`](https://github.com/NixOS/nixpkgs/commit/8fc6a95bff210c6465f242f87b9dc36afd24d972) | `dmidecode: support cross-compilation`                                                             |
| [`2ed7f96a`](https://github.com/NixOS/nixpkgs/commit/2ed7f96a78a59684a49ba306b6be1219e845e346) | `ocamlPackages.curses: 1.0.4 -> 1.0.8`                                                             |
| [`f9254974`](https://github.com/NixOS/nixpkgs/commit/f9254974fd262acd6caca800593fc7757df076ef) | `python39Packages.swift: ini at 2.28.0`                                                            |
| [`7bf5df75`](https://github.com/NixOS/nixpkgs/commit/7bf5df751821ca5c44dcf3014dced97d35402c01) | `python39Packages.pyeclib: init at 1.6.0`                                                          |
| [`42cf1c99`](https://github.com/NixOS/nixpkgs/commit/42cf1c99fe8be3daa83b52e2a996f21b010dc7c8) | `liberasurecode: ini at 1.6.2`                                                                     |
| [`1c7c0d64`](https://github.com/NixOS/nixpkgs/commit/1c7c0d64ebbbf1cbf96a56b614012a2c00aa4a76) | `python39Packages.pastedeploy: adopt into openstack team`                                          |
| [`20d7e6bc`](https://github.com/NixOS/nixpkgs/commit/20d7e6bc0d28c608d7fb117c281d5c047e0f2d8c) | `python3Packages.deezer-python: 2.3.1 -> 2.4.0`                                                    |
| [`334ea093`](https://github.com/NixOS/nixpkgs/commit/334ea0938ee3a731adeeeb768f2bd6c4fd980d17) | `python3Packages.deemix: 3.5.3 -> 3.5.5`                                                           |
| [`4f99e3af`](https://github.com/NixOS/nixpkgs/commit/4f99e3afe0221b05befe547b774e18579818f424) | `python3Packages.deezer-py: 1.2.4 -> 1.2.5`                                                        |
| [`3cd6f09a`](https://github.com/NixOS/nixpkgs/commit/3cd6f09aa2523ae2d5ed197ccd1805a97e71bf23) | `skytemple: 1.3.1 -> 1.3.2`                                                                        |
| [`84fc6e5b`](https://github.com/NixOS/nixpkgs/commit/84fc6e5bcc06dd4cd26a8d3b6f01d3fe8738d50f) | `python3Packages.skytemple-icons: 1.2.0 -> 1.3.2`                                                  |
| [`47ad5627`](https://github.com/NixOS/nixpkgs/commit/47ad56271c189c835c2eca214e06a18ffa34809a) | `python3Packages.skytemple-files: 1.3.1 -> 1.3.2`                                                  |
| [`20255498`](https://github.com/NixOS/nixpkgs/commit/202554980aec22f35078bf4c0878e2a0974cb2ce) | `nix: 2.3.15 -> 2.3.16`                                                                            |
| [`7a85a664`](https://github.com/NixOS/nixpkgs/commit/7a85a664cf699368759d5595e088e4d07efee5ab) | `tfsec: 0.58.12 -> 0.58.14`                                                                        |
| [`a4787593`](https://github.com/NixOS/nixpkgs/commit/a47875938d82d8d6b0d6aae3d709bc29999c4873) | `nix-fallback-paths.nix: Update to 2.3.16`                                                         |
| [`544ff6b4`](https://github.com/NixOS/nixpkgs/commit/544ff6b41294281c59926554b5a80e2860633641) | `wyvern: switch to fetchCrate, remove patch`                                                       |
| [`001bd7c4`](https://github.com/NixOS/nixpkgs/commit/001bd7c466817951efc58cda9929614b3bf41e27) | `cargo-update: 4.1.2 -> 7.0.1, switch to fetchCrate, remove patch`                                 |
| [`a168cfc4`](https://github.com/NixOS/nixpkgs/commit/a168cfc494eebc3ac272669ceb3ac1b38ea9db35) | `cargo-license: 0.3.0 -> 0.4.2, switch to fetchCrate, remove patch`                                |
| [`8b07d471`](https://github.com/NixOS/nixpkgs/commit/8b07d471b5c9e1b0bf4164ee4dea9912671be559) | `fst: fix version, switch to fetchCrate, remove patch`                                             |
| [`5561c9b7`](https://github.com/NixOS/nixpkgs/commit/5561c9b71260c7780234288e32b825745c6683bc) | `python39Packages.boto: some cleanup`                                                              |
| [`23dab135`](https://github.com/NixOS/nixpkgs/commit/23dab135572c6d4bfa3b11ca976f53e1a2f2fc31) | `superTuxKart: 1.2 -> 1.3`                                                                         |
| [`781972b2`](https://github.com/NixOS/nixpkgs/commit/781972b22f25e721d745b712aff4ec1a2f9c64ac) | `libopenglrecorder: init at unstable-2020-08-13`                                                   |
| [`92432797`](https://github.com/NixOS/nixpkgs/commit/92432797bd4a2025ca8239132081dba912cff306) | `angelscript: 2.35.0 -> 2.35.1`                                                                    |
| [`b9912f3d`](https://github.com/NixOS/nixpkgs/commit/b9912f3d90edf0edd6653a49a8aa0c88e491dab4) | `doh-proxy-rust: 0.3.8 -> 0.9.2, switch to fetchCrate, remove patch`                               |
| [`9d838fe0`](https://github.com/NixOS/nixpkgs/commit/9d838fe0b90f38c6fed0b8651085b73ea833c37b) | `effitask: 1.4.0 -> 1.4.1, fix build, remove patch`                                                |
| [`c4994585`](https://github.com/NixOS/nixpkgs/commit/c4994585299ad717a57453d5c4cd11e2dd338f6b) | `elfx86exts: remove unused patch`                                                                  |
| [`c1806a0e`](https://github.com/NixOS/nixpkgs/commit/c1806a0e65ab401d9f53b251363c559117a8df49) | `svd2rust: switch to fetchCrate, remove patch`                                                     |
| [`842c4970`](https://github.com/NixOS/nixpkgs/commit/842c49708e1ffa8990a65208916c0ce9a43b377e) | `fac-build: 0.5.3 -> 0.5.4, switch to fetchCrate, remove patch`                                    |
| [`4afe68d7`](https://github.com/NixOS/nixpkgs/commit/4afe68d75cf945e27b81e5d45405a8630a890678) | `sandboxfs: switch to fetchCrate, remove patch`                                                    |
| [`fc3ac0db`](https://github.com/NixOS/nixpkgs/commit/fc3ac0dbccd75feebf65a3419653969f2ad849c1) | `python3Packages.rainbowstream: 1.5.2 -> 1.5.5`                                                    |
| [`7efffa61`](https://github.com/NixOS/nixpkgs/commit/7efffa6104f84f9e0874c0710da370486236302c) | `python38Packages.phonenumbers: 8.12.33 -> 8.12.34`                                                |
| [`1d369f09`](https://github.com/NixOS/nixpkgs/commit/1d369f09634308b9a5a4603a88ea52014b537767) | `codeql: 2.5.9 -> 2.6.2`                                                                           |
| [`f9ae9403`](https://github.com/NixOS/nixpkgs/commit/f9ae94032f8b73191b06201e1d7ed3bcd606b7a7) | `codeql: update homepage`                                                                          |
| [`7aa5a5eb`](https://github.com/NixOS/nixpkgs/commit/7aa5a5eb8f52567efa0e91c7b0f7368327762a02) | `codeql: trim nativeBuildInputs`                                                                   |
| [`b757764b`](https://github.com/NixOS/nixpkgs/commit/b757764b66607e2e94badef3c361080e4728fbc4) | `wireshark: 3.4.8 -> 3.4.9`                                                                        |
| [`d609f3d7`](https://github.com/NixOS/nixpkgs/commit/d609f3d79b34c606bdaa62bc93a8ac0703ae2528) | `linux: 5.4.150 -> 5.4.151`                                                                        |
| [`86eb5c09`](https://github.com/NixOS/nixpkgs/commit/86eb5c0943f42026efed0bcd956094b1463d0281) | `linux: 5.14.9 -> 5.14.10`                                                                         |
| [`6a1f1237`](https://github.com/NixOS/nixpkgs/commit/6a1f12372598386f525524ff2d9a5ef49e4a6ac9) | `linux: 5.10.70 -> 5.10.71`                                                                        |
| [`e7e46322`](https://github.com/NixOS/nixpkgs/commit/e7e463220d2cd24d786be0f96c4e67c27577c0a3) | `linux: 4.9.284 -> 4.9.285`                                                                        |
| [`1dfb79c8`](https://github.com/NixOS/nixpkgs/commit/1dfb79c8874d7bf86c0575c2ea0b449f06106774) | `linux: 4.4.285 -> 4.4.287`                                                                        |
| [`098ad963`](https://github.com/NixOS/nixpkgs/commit/098ad9636ca54ac644177a193638fb2ec7c9fad6) | `linux: 4.19.208 -> 4.19.209`                                                                      |
| [`8d2f3a9f`](https://github.com/NixOS/nixpkgs/commit/8d2f3a9fb1a0a56ca58a10a6c3631b4d48baa2cc) | `linux: 4.14.248 -> 4.14.249`                                                                      |
| [`9b0a3cf1`](https://github.com/NixOS/nixpkgs/commit/9b0a3cf13c4bc9f1401551f3011ded6c5ccc0a1f) | `lefthook: 0.7.6 -> 0.7.7`                                                                         |
| [`c070d9ff`](https://github.com/NixOS/nixpkgs/commit/c070d9ff6663f6894423b3ecd4dc19e6f729ccb7) | `gdown: 4.0.1 -> 4.0.2`                                                                            |
| [`73ca1042`](https://github.com/NixOS/nixpkgs/commit/73ca104249d3ae4cf69008b1a7f1fe4d16093bf0) | `python38Packages.django-storages: 1.11.1 -> 1.12`                                                 |
| [`c0638c1d`](https://github.com/NixOS/nixpkgs/commit/c0638c1da26d3675d308e14a5869f4614b715480) | `python38Packages.ipyvue: 1.6.0 -> 1.6.1`                                                          |
| [`41574158`](https://github.com/NixOS/nixpkgs/commit/41574158a07f3c6ab5853b316c2fe7ed18e6354b) | `libgpg-error: rename from libgpgerror`                                                            |
| [`da49981f`](https://github.com/NixOS/nixpkgs/commit/da49981f02ea9c58ea9924b53eab79f54ff3809b) | `hydrus: 456 -> 457`                                                                               |
| [`43acf518`](https://github.com/NixOS/nixpkgs/commit/43acf518810e2db87adc45f501cf4417856d8321) | `utf8cpp: 3.1.2 -> 3.2.1`                                                                          |
| [`938cb219`](https://github.com/NixOS/nixpkgs/commit/938cb2195c2f2235c782ffbfd2be5f1235ec8d2d) | `pgloader: force the use of the version 2.0.8 of sbcl`                                             |
| [`e3ac5e15`](https://github.com/NixOS/nixpkgs/commit/e3ac5e1502b62d7aa72640f0d3edcb858a3690f8) | `nixos/varnish: add enableConfigCheck`                                                             |
| [`dab17335`](https://github.com/NixOS/nixpkgs/commit/dab17335e2c547c772b8d43965be71f281c12c57) | `python38Packages.jaraco_stream: 3.0.2 -> 3.0.3`                                                   |
| [`8f06773a`](https://github.com/NixOS/nixpkgs/commit/8f06773a49854dc9f6c933148e7a312e6bdf93fb) | `unifiedpush-common-proxies: init at 1.0.0`                                                        |
| [`d4fb3852`](https://github.com/NixOS/nixpkgs/commit/d4fb38527ea756d3adf4f04ca8c433437d7a0860) | `python38Packages.google-cloud-bigquery-datatransfer: 3.3.2 -> 3.3.4`                              |
| [`4f72c154`](https://github.com/NixOS/nixpkgs/commit/4f72c154239f2072f6377496fdcac6f415dfa643) | `quark-engine: init at 21.8.1`                                                                     |
| [`ea2e9f64`](https://github.com/NixOS/nixpkgs/commit/ea2e9f64f914930e681385df3e129968f41d3b01) | `sof-firmware: 1.7 -> 1.9`                                                                         |
| [`b2539bac`](https://github.com/NixOS/nixpkgs/commit/b2539bac632d136a8baffc443c8b92ef87a7588a) | `python38Packages.django_3: 3.2.7 -> 3.2.8`                                                        |
| [`9d166008`](https://github.com/NixOS/nixpkgs/commit/9d1660087090a8bac37e849ef049e80efd1c97c0) | `python38Packages.langcodes: 3.2.0 -> 3.2.1`                                                       |
| [`76b08fcb`](https://github.com/NixOS/nixpkgs/commit/76b08fcbbf08b18f44eb8c3d1fb96a8ef279ebd4) | `python3Packages.androguard: 3.3.5 -> 3.4.0a1`                                                     |
| [`2961446f`](https://github.com/NixOS/nixpkgs/commit/2961446fec86541ca496431d1a2370980834b36e) | `kube3d: 4.4.8 -> 5.0.0`                                                                           |
| [`e529a243`](https://github.com/NixOS/nixpkgs/commit/e529a24326ecececbf5d96e2014d41b79ee26a2b) | `python38Packages.jupyterlab: 3.1.14 -> 3.1.17`                                                    |
| [`39af076d`](https://github.com/NixOS/nixpkgs/commit/39af076d006228a789791a47cf58ff7c12ab33a0) | `onionshare: fix stem override`                                                                    |
| [`4bbe5cb9`](https://github.com/NixOS/nixpkgs/commit/4bbe5cb9d7d747e7c1cd623f4655be0cb1d807b8) | `Add myself as a maintainer`                                                                       |
| [`9f0bbe45`](https://github.com/NixOS/nixpkgs/commit/9f0bbe4576e466673ac9f2cf2f242c162d23ed3c) | `beekeeper-studio: init at 2.1.4`                                                                  |
| [`e47dd11f`](https://github.com/NixOS/nixpkgs/commit/e47dd11f4ae5c2d089cb32618e019eb67a5469ef) | `python38Packages.vyper: 0.2.16 -> 0.3.0`                                                          |
| [`29a8d549`](https://github.com/NixOS/nixpkgs/commit/29a8d549db9e3df6f05ff5711cdacea3db6b4f54) | `vscode-extensions.hashicorp.terraform: 2.14.0 -> 2.15.0`                                          |
| [`1fce5d42`](https://github.com/NixOS/nixpkgs/commit/1fce5d4252a584fdf9f854dbf023d2b992397f46) | `davix-copy: init as davix with enableThirdPartyCopy=true`                                         |
| [`9e972605`](https://github.com/NixOS/nixpkgs/commit/9e972605a04b36faebab34a821ec90aab13990e0) | `davix: add switches for optional features`                                                        |
| [`362cdf2c`](https://github.com/NixOS/nixpkgs/commit/362cdf2cc60c9a7a32c02ed785a8ba9aa2882a68) | `davix: 0.7.6 -> 0.8.0`                                                                            |
| [`fa3378e9`](https://github.com/NixOS/nixpkgs/commit/fa3378e9c42cde077e2e9572df86d6a8de42e943) | `pmacct: 1.7.5 -> 1.7.6`                                                                           |
| [`986159b8`](https://github.com/NixOS/nixpkgs/commit/986159b82391e8744ee8925c4287d17341febb5d) | `libcdada: init at 0.3.5`                                                                          |
| [`c5477e63`](https://github.com/NixOS/nixpkgs/commit/c5477e635ecbd52f6278310cecd70d69390162ac) | `python3Packages.rzpipe: init at 0.1.1`                                                            |
| [`51ee27ca`](https://github.com/NixOS/nixpkgs/commit/51ee27ca879609cf643eff1b54853bf9099dd64a) | `tutanota-desktop: init at 3.88.4`                                                                 |
| [`1f14a74e`](https://github.com/NixOS/nixpkgs/commit/1f14a74ec248641b2f6aca1db999298212329378) | `proot: 20190510 -> 5.2.0`                                                                         |
| [`b40b3057`](https://github.com/NixOS/nixpkgs/commit/b40b3057fe3da054013e74b6f64c995420ac27ba) | `zcash: 4.5.0 -> 4.5.1`                                                                            |
| [`f70e0175`](https://github.com/NixOS/nixpkgs/commit/f70e017500c1dfc0cb796231a423b92cc0aeb7c5) | `ryujinx: 1.0.7047 -> 1.0.7058`                                                                    |
| [`dbfca76a`](https://github.com/NixOS/nixpkgs/commit/dbfca76af06e7e4fd53cedb6e1ddc32a197909a9) | `pythonPackages.pytmx: 3.25 -> 3.27`                                                               |