### PR TITLE
chore(deps): update pre-commit-hooks

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3ed0e618cebc1ff291c27b749cf7568959cac028",
-        "sha256": "0zni3zpz544p7bs7a87wjhd6wb7jmicx0sf2s5nrqapnxa97zcs4",
+        "rev": "77b45d526e4dcc1f26ce449f5dc561f2e6eb5db6",
+        "sha256": "1j2w66b73hdr64dp2nk9pmxz63344wwxddyv8jrllgy7nv3j0rwa",
         "type": "tarball",
-        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/3ed0e618cebc1ff291c27b749cf7568959cac028.tar.gz",
+        "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/77b45d526e4dcc1f26ce449f5dc561f2e6eb5db6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                               |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`875f9f8a`](https://github.com/cachix/pre-commit-hooks.nix/commit/875f9f8acb7ed7a1c270706d2b3885c44a505de0) | `Add clang-format`                           |
| [`00a331d5`](https://github.com/cachix/pre-commit-hooks.nix/commit/00a331d5c84c065530aae5f270f53864f119a417) | `Remove deprecated warning about clippy bug` |