### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e84e5f8f36ef5320497e79f8aca6e811b066d2f",
-        "sha256": "0qf1227hrn8ddv1ip3mnx8gy2lw3h2ibz82qlr96s5b048x043w9",
+        "rev": "107a51dd71aa21234baf20baaeb613d7ff0214ce",
+        "sha256": "070hppxq5dq5zdfrrlqa6xj6naldgs0dakkmyhdvb31axn878hmg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9e84e5f8f36ef5320497e79f8aca6e811b066d2f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/107a51dd71aa21234baf20baaeb613d7ff0214ce.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`314a4950`](https://github.com/NixOS/nixpkgs/commit/314a49503af315c25a5fefb0eb3d088bd610ff32) | `libsForQt5.dxflib: 3.17.0 -> 3.26.4`                                     |
| [`463c567b`](https://github.com/NixOS/nixpkgs/commit/463c567becb387c462a7de387c20fcc567487e5c) | `cozydrive: fix maintainers`                                              |
| [`38314527`](https://github.com/NixOS/nixpkgs/commit/383145270fe9640fe07f9806845acf1b7849be3e) | `exploitdb: 2021-10-06 -> 2021-10-09`                                     |
| [`ed666b44`](https://github.com/NixOS/nixpkgs/commit/ed666b443daaaa4ea5a226606b4272c4b5286ff0) | `k0sctl: 0.10.3 -> 0.10.4`                                                |
| [`139ecccc`](https://github.com/NixOS/nixpkgs/commit/139ecccc84091cb1ee605cc77e221fd643517caa) | `home-assistant: disable tado test that needs network access`             |
| [`903dc5bf`](https://github.com/NixOS/nixpkgs/commit/903dc5bf924c87a466e93ed37001f9c1a6afbbd5) | `git: darwin: disable flaky tests`                                        |
| [`9b46db90`](https://github.com/NixOS/nixpkgs/commit/9b46db90ffb313e3d738be406d77c9ad0717ec84) | `electron_14: 14.1.0 -> 14.1.1`                                           |
| [`e0f5245a`](https://github.com/NixOS/nixpkgs/commit/e0f5245ab30f87ba4d357f8b3d32d6ed027a8f0f) | `electron_15: 15.1.1 -> 15.1.2`                                           |
| [`edf8f5d0`](https://github.com/NixOS/nixpkgs/commit/edf8f5d054d878adba911c8fdb26ecba19ae4db4) | `p7zip: fix determinism of compressed manpages`                           |
| [`4c9f6db4`](https://github.com/NixOS/nixpkgs/commit/4c9f6db483bcea854306e297b1426f07c035793f) | `python3Packages.proxmoxer: 1.1.1 -> 1.2.0`                               |
| [`83d2927d`](https://github.com/NixOS/nixpkgs/commit/83d2927d1e1dcaee7e07e89b00a58aa63e84494f) | `python3Packages.colorlog: 6.4.1 -> 6.5.0`                                |
| [`e8a12492`](https://github.com/NixOS/nixpkgs/commit/e8a12492fcc0c776a08ceafca93eb4a58564aca6) | `tdesktop: 3.1.8 -> 3.1.9`                                                |
| [`e19b6535`](https://github.com/NixOS/nixpkgs/commit/e19b6535d1c7a2edc499f9b392bbb0560c6bc9f9) | `keepalived: 2.2.2 -> 2.2.4`                                              |
| [`42f543b2`](https://github.com/NixOS/nixpkgs/commit/42f543b2173b3772c1f156feb6075acc805a5c0d) | `hurl: install manpages`                                                  |
| [`85bd79c7`](https://github.com/NixOS/nixpkgs/commit/85bd79c702e524761512d2a8a4a1730b4b85786e) | `actionlint: 1.6.4 -> 1.6.5`                                              |
| [`d02c87a3`](https://github.com/NixOS/nixpkgs/commit/d02c87a392cd964af20243e072b186f9efd90572) | `vscodium: 1.60.2 -> 1.61.0`                                              |
| [`508d862d`](https://github.com/NixOS/nixpkgs/commit/508d862dc72a4c2a1cb06700ab28ac319961e925) | `python39Packages.scrapy: 2.5.0 -> 2.5.1`                                 |
| [`06e0a8e4`](https://github.com/NixOS/nixpkgs/commit/06e0a8e43a18bcbda088b54c4b931cad842ef76d) | `time-ghc-modules: init at 1.0.0 (#140847)`                               |
| [`a1d3f8f4`](https://github.com/NixOS/nixpkgs/commit/a1d3f8f48e56cc4de2417a576ee9f82f8a2f4758) | `home-assistant: 2021.10.1 -> 2021.10.2`                                  |
| [`4a7a5d17`](https://github.com/NixOS/nixpkgs/commit/4a7a5d175ab5419fb170bb46dea2b2409e271c7b) | `python3Packages.async-upnp-client: 0.22.5 -> 0.22.8`                     |
| [`c1cf3662`](https://github.com/NixOS/nixpkgs/commit/c1cf3662a1488840420f25ebb95c0fdeb20f3b4e) | `python3Packages.python-didl-lite: 1.2.6 -> 1.3.0`                        |
| [`27ce3b12`](https://github.com/NixOS/nixpkgs/commit/27ce3b12b3d600155732eb014c02ca3dde180a24) | `home-assistant: 2021.10.0 -> 2021.10.1`                                  |
| [`55ed9b77`](https://github.com/NixOS/nixpkgs/commit/55ed9b77357ba2c7042af32b8c8e58293fd2ec06) | `_3270font: 2.3.0 -> 2.3.1`                                               |
| [`c8fff86c`](https://github.com/NixOS/nixpkgs/commit/c8fff86cd6dc7ddb3e8e804a9f3aff149191b72c) | `python3Packages.djangorestframework-simplejwt: add setuptools-scm`       |
| [`757d3b91`](https://github.com/NixOS/nixpkgs/commit/757d3b91a6cac8a3668bd003aa62c041022432f1) | `plexamp: update hash due to silent release`                              |
| [`a15be1c5`](https://github.com/NixOS/nixpkgs/commit/a15be1c5f65b15d75a4e30a82340ed34d538e449) | `chromiumBeta: 95.0.4638.32 -> 95.0.4638.40`                              |
| [`d406bca7`](https://github.com/NixOS/nixpkgs/commit/d406bca7461e94cb3c9544e7ccfb3c3bba6df1d2) | `chromium: 94.0.4606.71 -> 94.0.4606.81`                                  |
| [`5a2ecde0`](https://github.com/NixOS/nixpkgs/commit/5a2ecde0daa038cda090fef88d32e3a110c21e6f) | `gitea: 1.15.3 -> 1.15.4`                                                 |
| [`6b97150c`](https://github.com/NixOS/nixpkgs/commit/6b97150cda5b61bf5fee0f7385ec16dcb93654e1) | `python3Packages.hap-python: 4.1.0 -> 4.3.0`                              |
| [`530c363f`](https://github.com/NixOS/nixpkgs/commit/530c363fd2febb4231c37b31cdea4b713c4a0a90) | `cht-sh: set meta.mainProgram`                                            |
| [`8916d1cb`](https://github.com/NixOS/nixpkgs/commit/8916d1cbade66f97c4468bc2ed2c384eacca1f68) | `mmv-go: set meta.mainProgram`                                            |
| [`b433e3ee`](https://github.com/NixOS/nixpkgs/commit/b433e3eed718b90a65b72316ebb732b4c5e8886f) | `fet-sh: set meta.mainProgram`                                            |
| [`899376d4`](https://github.com/NixOS/nixpkgs/commit/899376d4be8db5880ee7137a389f50281dd5f479) | `licensor: set meta.mainProgram`                                          |
| [`bb73ba8e`](https://github.com/NixOS/nixpkgs/commit/bb73ba8e24f6b63593c76a0b1140987c9d921bfb) | `vimv: set meta.mainProgram`                                              |
| [`14172a1f`](https://github.com/NixOS/nixpkgs/commit/14172a1f095dfb7d9e648cb2512424cf9e23a46a) | `fsearch: set meta.mainProgram`                                           |
| [`9abb78b9`](https://github.com/NixOS/nixpkgs/commit/9abb78b9ed6fdb76d6fd6cb42b83317b8e7a95e0) | `git-fire: set meta.mainProgram`                                          |
| [`5b494333`](https://github.com/NixOS/nixpkgs/commit/5b494333fc19552d1450729692fa93be1e719036) | `loop: set meta.mainProgram`                                              |
| [`4a49db32`](https://github.com/NixOS/nixpkgs/commit/4a49db328dea341e37a85271883400da4999e23a) | `powerline-go: set meta.mainProgram`                                      |
| [`c2cd2218`](https://github.com/NixOS/nixpkgs/commit/c2cd221888a079fb7860a7a764d0f2a9cbfe3b1b) | `sta: set meta.mainProgram`                                               |
| [`01b6b651`](https://github.com/NixOS/nixpkgs/commit/01b6b651b4864e68a44b47c9b9f65a411112be2a) | `zoneminder: 1.34.22 -> 1.36.8`                                           |
| [`a0926da3`](https://github.com/NixOS/nixpkgs/commit/a0926da31986f4f7ac889769b628ff347b63a755) | `bunnyfetch: set meta.mainProgram`                                        |
| [`60eb8d62`](https://github.com/NixOS/nixpkgs/commit/60eb8d62a7bc03c4753e78340f7881a803224586) | `colorpicker: set meta.mainProgram`                                       |
| [`1d4d39f0`](https://github.com/NixOS/nixpkgs/commit/1d4d39f0bcd4f11cae9ccbf717b99f124a83d8ed) | `fasd: set meta.mainProgram`                                              |
| [`91c2bef3`](https://github.com/NixOS/nixpkgs/commit/91c2bef35c45313f175777bfa3d213dea1525903) | `xtrt: set meta.mainProgram`                                              |
| [`ac12e3e6`](https://github.com/NixOS/nixpkgs/commit/ac12e3e6733210a24859af36f92b1e21cf75333c) | `nitter: set meta.mainProgram`                                            |
| [`acd32002`](https://github.com/NixOS/nixpkgs/commit/acd320020d1b058f8f46893a86b410743b475d4d) | `vgo2nix: set meta.mainProgram`                                           |
| [`6c0b7989`](https://github.com/NixOS/nixpkgs/commit/6c0b7989feb82fcb3b88878c6c258b9dc57777f0) | `bunyan-rs: set meta.mainProgram`                                         |
| [`e878a508`](https://github.com/NixOS/nixpkgs/commit/e878a508352ad489760d0fab9ebfe5d0c116efbc) | `gir-rs: set meta.mainProgram`                                            |
| [`06bb6325`](https://github.com/NixOS/nixpkgs/commit/06bb6325b7267924631e81a44ccc69d0ca05f7ea) | `pax-rs: set meta.mainProgram`                                            |
| [`8234f81d`](https://github.com/NixOS/nixpkgs/commit/8234f81d9f81c611a1f4a831f87d758d3dbbce83) | `tab-rs: set meta.mainProgram`                                            |
| [`bf416786`](https://github.com/NixOS/nixpkgs/commit/bf4167861d0f864b0fc457778d54feb4a2675ea2) | `python38Packages.pynws: 1.3.1 -> 1.3.2`                                  |
| [`53fac4e4`](https://github.com/NixOS/nixpkgs/commit/53fac4e4e5c242879b5ff108dab57a272dc5855a) | `python3Packages.orjson: 3.6.3 -> 3.6.4`                                  |
| [`a20824eb`](https://github.com/NixOS/nixpkgs/commit/a20824eb698acee719278982b1a973f55d65130e) | `python38Packages.sagemaker: 2.59.7 -> 2.59.8`                            |
| [`0820a196`](https://github.com/NixOS/nixpkgs/commit/0820a196651dfe59af13ec4fbe558f2686d82fe3) | `python38Packages.pyopencl: 2021.2.6 -> 2021.2.8`                         |
| [`8df24c97`](https://github.com/NixOS/nixpkgs/commit/8df24c977d99362dafb3461d0b2e3d6686795d8f) | `python38Packages.mypy-boto3-s3: 1.18.56 -> 1.18.57`                      |
| [`a35e0cc0`](https://github.com/NixOS/nixpkgs/commit/a35e0cc00b5fb807dd6631995381fcc3c4d4e326) | `python38Packages.pykka: 3.0.1 -> 3.0.2`                                  |
| [`48642bff`](https://github.com/NixOS/nixpkgs/commit/48642bff7689ea95650ac16c968887610368f675) | `python38Packages.pyexcel-io: 0.6.4 -> 0.6.5`                             |
| [`545fca99`](https://github.com/NixOS/nixpkgs/commit/545fca99f20d7109e6ffe50f985de50e7392ad52) | `nodejs-16_x: 16.10.0 -> 16.11.0`                                         |
| [`96787341`](https://github.com/NixOS/nixpkgs/commit/96787341868b9ab7c0135b29b0eed3e6242cc6e1) | `quark-engine: 21.8.1 -> 21.10.2`                                         |
| [`886cae19`](https://github.com/NixOS/nixpkgs/commit/886cae196c35d416452da3307c0957400793ee1d) | `osu-lazer: set meta.mainProgram`                                         |
| [`1c04f9f1`](https://github.com/NixOS/nixpkgs/commit/1c04f9f1764b2c17ca8bd95df452b543fecaa912) | `qcengine: 0.20.0 -> 0.20.1`                                              |
| [`1af3ef78`](https://github.com/NixOS/nixpkgs/commit/1af3ef788ac999472933d19560e3cc94fee55acd) | `grype: 0.19.0 -> 0.22.0`                                                 |
| [`ab92e922`](https://github.com/NixOS/nixpkgs/commit/ab92e922cb86f451f7b025ac1112d18d00be4a5f) | `protonvpn-gui: clarify license, set meta.mainProgram`                    |
| [`d90c323b`](https://github.com/NixOS/nixpkgs/commit/d90c323b8ee3cc1a47de6741ea1d4b71a8a52eb8) | `protonvpn-cli: clarify license, set meta.mainProgram`                    |
| [`6799a3c3`](https://github.com/NixOS/nixpkgs/commit/6799a3c373eb0f2670e058dd28b4ede5e0707928) | `python3Packages.fastapi: 0.68.1 -> 0.70.0`                               |
| [`7d7ebb8f`](https://github.com/NixOS/nixpkgs/commit/7d7ebb8ffd3ad36aaafe98993c976e42c6fbbc77) | `python38Packages.pyexcel-xls: 0.6.2 -> 0.7.0`                            |
| [`65977652`](https://github.com/NixOS/nixpkgs/commit/659776521ac4457c2fed1d496701d7e57bda9b6c) | `python3Packages.databases: 0.5.0 -> 0.5.2`                               |
| [`5bc899aa`](https://github.com/NixOS/nixpkgs/commit/5bc899aa0e6ccaec68e514f6cd738cb582ba2898) | `python3Packages.aiopg: 1.3.1 -> 1.3.2`                                   |
| [`f6243ca1`](https://github.com/NixOS/nixpkgs/commit/f6243ca1e6e8490e971f8c69f6678f0b60e4747f) | `tdesktop: 3.1.1 -> 3.1.8`                                                |
| [`62dc8ef7`](https://github.com/NixOS/nixpkgs/commit/62dc8ef7790b8a4707f2887246a57b9a8347ed6b) | `clickhouse: 21.3.11.5 -> 21.8.8.29`                                      |
| [`b44e0ef9`](https://github.com/NixOS/nixpkgs/commit/b44e0ef9ce7cfdb05cf22bf02da8438edc2d7595) | `matrix-synapse: also expose `synapse.app.generic_worker` via `setup.py`` |
| [`b0ab15b0`](https://github.com/NixOS/nixpkgs/commit/b0ab15b0a12a2d9cacba0e0185589d905527df26) | `nixos/matrix-synapse: expose rendered config file as readOnly option`    |
| [`aa02e7f8`](https://github.com/NixOS/nixpkgs/commit/aa02e7f8280f93199e2adb6d36a8fa5f3163bca0) | `avogadro2: initialise a translation repo`                                |
| [`1ce86034`](https://github.com/NixOS/nixpkgs/commit/1ce86034714cbe493ea7be45e77d17706302d50d) | `libmsym: fixing homepage`                                                |
| [`181689df`](https://github.com/NixOS/nixpkgs/commit/181689dfea3cbf41ec616e012b9ee5c172d3213f) | `avogadro2: 1.94.0 -> 1.95.1`                                             |
| [`510ed22d`](https://github.com/NixOS/nixpkgs/commit/510ed22d749529f685318766737a4be75e6fe32c) | `avogadrolibs: 1.94.0 -> 1.95.1`                                          |
| [`b27d18a4`](https://github.com/NixOS/nixpkgs/commit/b27d18a412b071f5d7991d1648cfe78ee7afe68a) | `yarn2nix: handle codeload.github.com uris in IFD mode (#136922)`         |
| [`692903a7`](https://github.com/NixOS/nixpkgs/commit/692903a7432c378ba403b7fc502cff71a637e8ea) | `tela-icon-theme: 2021-01-21 -> 2021-10-08`                               |
| [`ebf42c50`](https://github.com/NixOS/nixpkgs/commit/ebf42c50c7bb613a590b8bd263d9043569087b37) | `vscode: 1.60.2 -> 1.61.0`                                                |
| [`bcae9bb6`](https://github.com/NixOS/nixpkgs/commit/bcae9bb64fa51b8a4651ac16a8a543d04b5b6ef1) | `portfolio: 0.54.2 -> 0.55.0`                                             |
| [`7381e553`](https://github.com/NixOS/nixpkgs/commit/7381e553a56da34465b813ad75024cd0bd651682) | `apacheHttpd: 2.4.50 -> 2.4.51`                                           |
| [`d77c75a9`](https://github.com/NixOS/nixpkgs/commit/d77c75a98eb18f9c79d0e31d27973033e4e83d42) | `nixos/nix-daemon: Clarify daemonNiceLevel`                               |
| [`f5c5f132`](https://github.com/NixOS/nixpkgs/commit/f5c5f132684b0c0f6b43e07ff21c9ef380e870e3) | `yq-go: add mainProgram`                                                  |
| [`3a6bad3c`](https://github.com/NixOS/nixpkgs/commit/3a6bad3cd0461343ae670af29da04cbef3ea8ad7) | `esphome: 2021.9.2 -> 2021.9.3`                                           |
| [`2610075c`](https://github.com/NixOS/nixpkgs/commit/2610075c6d63a30f10a1e5ddf91564aa10c8501b) | `python38Packages.google-cloud-websecurityscanner: 1.4.2 -> 1.5.0`        |
| [`d33a1ca6`](https://github.com/NixOS/nixpkgs/commit/d33a1ca67732cb769eff969f92710e2b83a88e4c) | `polkadot: 0.9.10 -> 0.9.11`                                              |
| [`0439b500`](https://github.com/NixOS/nixpkgs/commit/0439b500a3e01e9fc1bc15ac173533955c0f3dfc) | `python3Packages.aionanoleaf: 0.0.2 -> 0.0.3`                             |
| [`dcb18f7a`](https://github.com/NixOS/nixpkgs/commit/dcb18f7a13cf2f3bdf41df91d8d8f2f2e92d83a7) | `python38Packages.google-cloud-trace: 1.3.3 -> 1.4.0`                     |
| [`cea45bb7`](https://github.com/NixOS/nixpkgs/commit/cea45bb7c5a5a0adcd1abb6a48036717fe8f393a) | `python38Packages.google-cloud-securitycenter: 1.5.1 -> 1.6.0`            |
| [`09cb1cdb`](https://github.com/NixOS/nixpkgs/commit/09cb1cdb076bff2ffe963c7e68ab4d2ad5db64b4) | `python38Packages.google-cloud-resource-manager: 1.1.1 -> 1.2.0`          |
| [`568edc1d`](https://github.com/NixOS/nixpkgs/commit/568edc1d4f14b97903f4d00246a852469527250c) | `jrsonnet: install shell completions`                                     |
| [`a4fbde2c`](https://github.com/NixOS/nixpkgs/commit/a4fbde2c36cc58c48786d60e817024ff997a7026) | `slurm: 21.08.1.1 -> 21.08.2.1`                                           |
| [`fae8dcf6`](https://github.com/NixOS/nixpkgs/commit/fae8dcf601e5f8d78b6f834d08a0cd98b86c365b) | `ec2_api_tools -> ec2-api-tools`                                          |
| [`57346520`](https://github.com/NixOS/nixpkgs/commit/57346520fcdfa8ff78278585f8851e9803303d0a) | `ec2_ami_tools -> ec2-ami-tools`                                          |
| [`0bd4ce05`](https://github.com/NixOS/nixpkgs/commit/0bd4ce05b3c5f92fa18634e7523f361127eff268) | `remkrom: add meta.mainProgram`                                           |
| [`16c2bce1`](https://github.com/NixOS/nixpkgs/commit/16c2bce1fb13931cf277e2919c1ec9fbf3392509) | `fishPlugins.pisces: init at 0.7.0`                                       |
| [`40c8d56f`](https://github.com/NixOS/nixpkgs/commit/40c8d56f4032f807673ead87e7c66fa9cf063d60) | `regenkfs: add meta.mainProgram`                                          |
| [`9f449eaf`](https://github.com/NixOS/nixpkgs/commit/9f449eaf24c8e7f0f68fdab528d67c484d57db89) | `crun: 1.1 -> 1.2`                                                        |
| [`19438d7d`](https://github.com/NixOS/nixpkgs/commit/19438d7d371888ef09fb4c90217a2ca0e4670b4d) | `remkrom: add meta.mainProgram`                                           |
| [`f3cdffa9`](https://github.com/NixOS/nixpkgs/commit/f3cdffa9de55cc6152085d5d9df99329aa3dae8c) | `python38Packages.chess: 1.6.1 -> 1.7.0`                                  |
| [`86d5c2aa`](https://github.com/NixOS/nixpkgs/commit/86d5c2aa63184a867ca0326eb929860ac374a43a) | `python3Packages.pymsteams: 0.1.15 -> 0.1.16`                             |
| [`a3a5641c`](https://github.com/NixOS/nixpkgs/commit/a3a5641c4d0a315c27d17f39a24b8e940092e27b) | `python3Packages.pontos: 21.10.0 -> 21.10.2`                              |
| [`0a33bead`](https://github.com/NixOS/nixpkgs/commit/0a33beadb36ee02255cc216b31ac45664b109ec2) | `hurl: fix build on darwin`                                               |
| [`28b03b98`](https://github.com/NixOS/nixpkgs/commit/28b03b98370b41fabc6201f71fe0d90d69bcdd78) | `python3Packages.yeelight: 0.7.6 -> 0.7.7`                                |
| [`3f61540e`](https://github.com/NixOS/nixpkgs/commit/3f61540e57995f460fd956d9aabaa4be4c8c3fbf) | `python3Packages.censys: 2.0.8 -> 2.0.9`                                  |
| [`8ebffb17`](https://github.com/NixOS/nixpkgs/commit/8ebffb174b470c28b378dd6ff83a0bd0becd0a35) | `amass: 3.14.0 -> 3.14.1`                                                 |
| [`47add920`](https://github.com/NixOS/nixpkgs/commit/47add9203dd667dacb80977817ed7cc1e18e107d) | `osu-lazer: 2021.815.0 -> 2021.1006.1`                                    |
| [`21225494`](https://github.com/NixOS/nixpkgs/commit/21225494766730afdd6fb2227bad947e6426d2c6) | `dapl: init at 0.2.0+unstable=2021-06-30`                                 |
| [`6d7fd894`](https://github.com/NixOS/nixpkgs/commit/6d7fd894532f094b6d60267c3f340b3e0a671e9b) | `coreboot-toolchain: Set pname instead of name`                           |
| [`4ce09e0e`](https://github.com/NixOS/nixpkgs/commit/4ce09e0e060e0d268810f4957f19ba35f10c2c04) | `lean: 3.32.1 → 3.33.0`                                                   |
| [`ec215f45`](https://github.com/NixOS/nixpkgs/commit/ec215f45f297fbbc04d65afe5bc9482071bad581) | `freshfetch: switch to cargoSha256, remove vendored Cargo.lock`           |
| [`ccc491f1`](https://github.com/NixOS/nixpkgs/commit/ccc491f1808424923039a40be0c3ef6ed42233cc) | `dnspeep: switch to cargoSha256, remove vendored Cargo.lock`              |
| [`e0629655`](https://github.com/NixOS/nixpkgs/commit/e06296554499414a8dc00d72861cc49812024535) | `cargo-binutils: switch to fetchCrate, remove vendored Cargo.lock`        |
| [`02dcd88d`](https://github.com/NixOS/nixpkgs/commit/02dcd88d27d747703d4ca3e3f8d105611d55b362) | `diesel-cli: clean up`                                                    |
| [`82b780a5`](https://github.com/NixOS/nixpkgs/commit/82b780a5b6024279a2a503994fb453c8da8b33b4) | `shticker-book-unwritten: switch to fetchCrate, remove patch`             |
| [`1eae448e`](https://github.com/NixOS/nixpkgs/commit/1eae448e429c77b9b322bf663ff72468db6e3765) | `eva: switch to fetchCrate, remove patch`                                 |
| [`550ac38a`](https://github.com/NixOS/nixpkgs/commit/550ac38a18558d3b2bfde7a402857d03189f6d35) | `bottom-rs: unstable-2021-04-27 -> 1.2.0, clean up`                       |
| [`56fa7bd6`](https://github.com/NixOS/nixpkgs/commit/56fa7bd6b4c817c0b3a2b54c7869619735c6a827) | `Update koreader to 2021.09`                                              |
| [`098d3a83`](https://github.com/NixOS/nixpkgs/commit/098d3a83a503579d7571ca9af4ebb5a7349546b8) | `renderdoc: 1.15 -> 1.16`                                                 |
| [`8247f98c`](https://github.com/NixOS/nixpkgs/commit/8247f98c1923d0dd04ce4829c441fb1b6554c71e) | `python3Packages.millheater: 0.6.0 -> 0.6.1`                              |
| [`ba81f10f`](https://github.com/NixOS/nixpkgs/commit/ba81f10fcefaeaf4bf021c031ff51f41f24bc3c9) | `python3Packages.ambee: 0.3.0 -> 0.4.0`                                   |
| [`31f04fec`](https://github.com/NixOS/nixpkgs/commit/31f04fec3c4c993d75ea4c7243fbc57103525282) | `nixos/wakeonlan: remove`                                                 |
| [`bb3ea37e`](https://github.com/NixOS/nixpkgs/commit/bb3ea37eeed0da6dbd2c6a6c08abbdd16cf5f875) | `nixos/networking: add the wakeonlan option`                              |
| [`8e57c33a`](https://github.com/NixOS/nixpkgs/commit/8e57c33ab6b284be5053717daba75a18c285cd5b) | `pkgsLLVM.grpc: fix build with clang < 11`                                |
| [`34ca27bc`](https://github.com/NixOS/nixpkgs/commit/34ca27bc95261256846ee8d0ebcdf4aeafef907a) | `grpc: don't set LD_LIBRARY_PATH when cross compiling`                    |
| [`973639dc`](https://github.com/NixOS/nixpkgs/commit/973639dcf106b2f776c8d8b95dd1ec786be47091) | `bundlerEnv.wrappedRuby: inherit gemPath and meta`                        |
| [`a200db7d`](https://github.com/NixOS/nixpkgs/commit/a200db7d9e81e10a1e8a377dcaf236c0b6dc8c81) | `thunderbird-unwrapped: 91.1.2 -> 91.2.0`                                 |
| [`f6db2063`](https://github.com/NixOS/nixpkgs/commit/f6db2063862470a1edc9592222e18b8cf00a114e) | `github-runner: 2.283.1 -> 2.283.3`                                       |
| [`5fb4d448`](https://github.com/NixOS/nixpkgs/commit/5fb4d4488ec96f73ea92d155914eea9c6c741086) | `python3Packages.dateparser: 1.0.0 -> 1.1.0`                              |
| [`a1e297d2`](https://github.com/NixOS/nixpkgs/commit/a1e297d282475408c56bf90ad97063e97765642f) | `mavproxy: 1.8.43 -> 1.8.44`                                              |
| [`48136819`](https://github.com/NixOS/nixpkgs/commit/4813681933a1c6b16a8c0ea3f02ea306cb6bccba) | `matrix-synapse: 1.43.0 -> 1.44.0`                                        |
| [`07b80a29`](https://github.com/NixOS/nixpkgs/commit/07b80a29ae3503888c5ccd7b4ec1def7991a71c9) | `haskellPackages.hakyll-images: clean up override`                        |
| [`dd887b4d`](https://github.com/NixOS/nixpkgs/commit/dd887b4d18ad5caa28b6328a85f12523bb484d96) | `haskellPackages: regenerate package set based on current config`         |
| [`2a9f449d`](https://github.com/NixOS/nixpkgs/commit/2a9f449dff2805a82464b0004475c0eafe156a8b) | `all-cabal-hashes: 2021-10-05T05:41:58Z -> 2021-10-05T05:41:58Z`          |
| [`01103187`](https://github.com/NixOS/nixpkgs/commit/011031876426009d398db7b1e17d20398a885fdd) | `python38Packages.python-stdnum: 1.16 -> 1.17`                            |
| [`17d18904`](https://github.com/NixOS/nixpkgs/commit/17d18904e2bed21deea8f65cef27f741adb4ab08) | `common-updater-scripts/update-source-version: Fix on Nix 2.4`            |
| [`8ae7cd8a`](https://github.com/NixOS/nixpkgs/commit/8ae7cd8a93ce916e13bf6bdd76bf5ff68f6e333c) | `common-updater-scripts/*: /bin/sh -> /usr/bin/env bash`                  |
| [`9a1bf524`](https://github.com/NixOS/nixpkgs/commit/9a1bf524f52cc662abf85b2737f7d0f5037bb85f) | `common-updater-scripts/list-git-tags: don't print commands`              |
| [`5f9e0699`](https://github.com/NixOS/nixpkgs/commit/5f9e06998409ec2538c6553b81774655a6d73a38) | `modules/nix-daemon: Explain nice level limitations`                      |
| [`5ffc8972`](https://github.com/NixOS/nixpkgs/commit/5ffc897238e5cef63795a06a028f1e6afbff97f1) | `python38Packages.databricks-connect: 8.1.13 -> 8.1.14`                   |
| [`7c47e9dc`](https://github.com/NixOS/nixpkgs/commit/7c47e9dc91de5d073956c43e896e2e3d6b0960f7) | `python38Packages.pyscard: 2.0.1 -> 2.0.2`                                |
| [`2090318d`](https://github.com/NixOS/nixpkgs/commit/2090318d75b5400a6b6b7f37f490a200c8f43692) | `nixos/jitsi-meet: add support for xmpp-websocket`                        |
| [`f9d95f30`](https://github.com/NixOS/nixpkgs/commit/f9d95f30a4989200ff7f34f3d572d787e47dbbf6) | `use steam-run to launch wps`                                             |