### PR TITLE
ci: remove duplicate macos CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - macos-11
           - ubuntu-latest
         python-version:
           - "3.7"


### PR DESCRIPTION
macos-latest now runs 11.x
