### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef",
-        "sha256": "1w6y7ma2crcsfph60z8j1k3af0v2m110cbjrb62z287mn4skhqjs",
+        "rev": "2ae14350dd34a0795ec418a03c076ad6205c0962",
+        "sha256": "0p8vc1p45xw063a22wl4jqikmsjbyga8a8zf1npyswday95156ax",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2ae14350dd34a0795ec418a03c076ad6205c0962.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`307a7c38`](https://github.com/NixOS/nixpkgs/commit/307a7c38cc0a76fddc953d144a14c918e2819c1b) | `ocamlPackages.uunf: 13.0.0 → 14.0.0`                                         |
| [`4a20098f`](https://github.com/NixOS/nixpkgs/commit/4a20098f21414b0183c491f5ea7abfc21c288292) | `nodejs: add changelog`                                                       |
| [`ed75efa8`](https://github.com/NixOS/nixpkgs/commit/ed75efa8783d32390254b17a208e3f0ef6c0e4d5) | `nodejs-16_x: 16.11.0 -> 16.11.1`                                             |
| [`611da87f`](https://github.com/NixOS/nixpkgs/commit/611da87f3fc5cc26d42aede17aca8b10b6d7f327) | `nodejs-12_x: 12.22.6 -> 12.22.7`                                             |
| [`f9da99e4`](https://github.com/NixOS/nixpkgs/commit/f9da99e40dba0ada984540af75243d811bf5d6a9) | `mavproxy: 1.8.44 -> 1.8.45`                                                  |
| [`615989e0`](https://github.com/NixOS/nixpkgs/commit/615989e078ae8b21a948d3d1c05b40da730ffb4d) | `go_1_17: 1.17.1 -> 1.17.2`                                                   |
| [`dcb39fae`](https://github.com/NixOS/nixpkgs/commit/dcb39fae95fcb9c2ad3f897d5ee858ac2280b4d8) | `go_1_16: 1.16.8 -> 1.16.9`                                                   |
| [`a01b2ba7`](https://github.com/NixOS/nixpkgs/commit/a01b2ba75f01ed36fc5803f1577a61f496b6524e) | `mirage-im: 0.6.4 -> 0.7.2`                                                   |
| [`d0e647cd`](https://github.com/NixOS/nixpkgs/commit/d0e647cde30e92ed8db8528666878febbacc5575) | `element-desktop: 1.9.0 -> 1.9.2`                                             |
| [`6ed00026`](https://github.com/NixOS/nixpkgs/commit/6ed000269b404d690c4927400788ddfef98f0eae) | `element-web: 1.9.0 -> 1.9.2`                                                 |
| [`cba4bd3f`](https://github.com/NixOS/nixpkgs/commit/cba4bd3f1072e50a197bf2092f84727fc294843a) | `element-desktop: fix update script`                                          |
| [`de2b7622`](https://github.com/NixOS/nixpkgs/commit/de2b7622bfffb214d9c0ec6e3b3787e0d69f5802) | `devserver: init at 0.4.0`                                                    |
| [`b18a7461`](https://github.com/NixOS/nixpkgs/commit/b18a7461690d13193a376725d8ac98a8131f72f9) | `yices: 2.6.1 -> 2.6.3 (#141241)`                                             |
| [`bf0f9f9d`](https://github.com/NixOS/nixpkgs/commit/bf0f9f9d3de4d7fbe09f2e09890cb97a2b9cf69b) | `python38Packages.vertica-python: 1.0.1 -> 1.0.2`                             |
| [`475e2a7e`](https://github.com/NixOS/nixpkgs/commit/475e2a7e33ca5b3a8197e3dff7ce655bc31b959f) | `python3Packages.python-telegram-bot: relax cachetools constraint`            |
| [`a4063f61`](https://github.com/NixOS/nixpkgs/commit/a4063f61679f5d8e40d564c1afcd131786fa35a1) | `python3Packages.immutabledict: 2.2.0 -> 2.2.1`                               |
| [`de681ae2`](https://github.com/NixOS/nixpkgs/commit/de681ae262d348e17afaa9fc488137d823e0201d) | `python38Packages.types-protobuf: 3.17.4 -> 3.17.5`                           |
| [`a3e5ba58`](https://github.com/NixOS/nixpkgs/commit/a3e5ba58fd1d83cd91f43cc9a81ba28a91bd2aae) | `mdbook-graphviz: init at 0.1.2 (#141395)`                                    |
| [`4ef84bba`](https://github.com/NixOS/nixpkgs/commit/4ef84bba5ec350fd7f66ec8c5049964db0e41659) | `python38Packages.types-futures: 3.3.0 -> 3.3.1`                              |
| [`b326a183`](https://github.com/NixOS/nixpkgs/commit/b326a183f4e140db31038453303688baf7507966) | `couchdb3: 3.1.1 -> 3.2.0`                                                    |
| [`590320c4`](https://github.com/NixOS/nixpkgs/commit/590320c4fe6e98fb977215e5fc5f0a258304bad8) | `python3Packages.angrop: 9.0.10072 -> 9.0.10159`                              |
| [`a3ad6043`](https://github.com/NixOS/nixpkgs/commit/a3ad6043385efcb907986dcd0136d049d6f7cff9) | `python3Packages.angr: 9.0.10072 -> 9.0.10159`                                |
| [`805d9425`](https://github.com/NixOS/nixpkgs/commit/805d94255716ea2f1777cbacddf8b3dbfc46e7c4) | `python3Packages.cle: 9.0.10072 -> 9.0.10159`                                 |
| [`6cb0a682`](https://github.com/NixOS/nixpkgs/commit/6cb0a6823811e7ad43df1d3a731fbddce8349d85) | `python3Packages.claripy: 9.0.10072 -> 9.0.10159`                             |
| [`844de678`](https://github.com/NixOS/nixpkgs/commit/844de678ff98015f6a1f55ad925784b72beef161) | `python3Packages.pyvex: 9.0.10072 -> 9.0.10159`                               |
| [`a75e4364`](https://github.com/NixOS/nixpkgs/commit/a75e4364c7c200fb1c6ac213ec0675c7e726fbf3) | `python3Packages.ailment: 9.0.10072 -> 9.0.10159`                             |
| [`f779de32`](https://github.com/NixOS/nixpkgs/commit/f779de3214d79eb5c8aa59b6fc0214511c47b735) | `python3Packages.archinfo: 9.0.10072 -> 9.0.10159`                            |
| [`36223baf`](https://github.com/NixOS/nixpkgs/commit/36223baf895e179808017c50459867fb5a5147fa) | `ytcc: 2.4.2 -> 2.5.0`                                                        |
| [`1a5a55a7`](https://github.com/NixOS/nixpkgs/commit/1a5a55a7fa848c169cae8e1a34904eedde38eebb) | `damon: init at unstable-2021-10-12`                                          |
| [`2323dec4`](https://github.com/NixOS/nixpkgs/commit/2323dec4d174bf3e993ba40637c1aa1cf8538a39) | `maintainers: fix manveru's name`                                             |
| [`f3ea5dea`](https://github.com/NixOS/nixpkgs/commit/f3ea5dead1ca8694ac583a45700fa10abb86c44b) | `python3Packages.lsassy: 2.1.5 -> 3.0.0`                                      |
| [`988c9012`](https://github.com/NixOS/nixpkgs/commit/988c9012cf07ed4896906b1dcf1ab5513c721543) | `lagrange: 1.7.1 → 1.7.2`                                                     |
| [`24cd85e2`](https://github.com/NixOS/nixpkgs/commit/24cd85e2c6c440d045e23c7c223406faf7019f5f) | `xtitle: minor cleanup`                                                       |
| [`9bd158f4`](https://github.com/NixOS/nixpkgs/commit/9bd158f4617d619ec4017df1926c7a6b75126f55) | `txt2man: minor cleanups, don't overwrite patchPhase, use makeFlags directly` |
| [`1d864209`](https://github.com/NixOS/nixpkgs/commit/1d864209168ce8a0ad306f41d79cbfd797b8af7c) | `sdate: move autoreconfHook to nativeBuildInputs, minor cleanups`             |
| [`45ae719f`](https://github.com/NixOS/nixpkgs/commit/45ae719fb53aa0a41d21f0c12ea85ca1e37f5d25) | `profile-sync-daemon: remove preferLocalBuild`                                |
| [`f8d3ae5d`](https://github.com/NixOS/nixpkgs/commit/f8d3ae5d0a4706825fcdfe57af3ee49e9e2fe93c) | `contacts: remove extra lib`                                                  |
| [`f1ed3ba5`](https://github.com/NixOS/nixpkgs/commit/f1ed3ba54c6e3630776d041ccd84c5b1bb444ceb) | `ccze: move autoconf to nativeBuildInputs`                                    |
| [`501884ff`](https://github.com/NixOS/nixpkgs/commit/501884ff7da8caaebc718638da0b66d157613fed) | `xboxdrv: minor cleanup`                                                      |
| [`edf14446`](https://github.com/NixOS/nixpkgs/commit/edf14446d8c082ea6c0b9be6d92ff6068007ee4b) | `python38Packages.scikit-optimize: 0.8.1 -> 0.9.0`                            |
| [`6a01f68d`](https://github.com/NixOS/nixpkgs/commit/6a01f68d8315d947c64df849e828fa3550796de3) | `python3Packages.pyhaversion: 21.10.1 -> 21.10.0`                             |
| [`cf168b36`](https://github.com/NixOS/nixpkgs/commit/cf168b36b3968ce8bf1e7c0ec9a5cff679e40539) | `python3Packages.simple-rest-client: 1.0.8 -> 1.1.0`                          |
| [`d8b35aa9`](https://github.com/NixOS/nixpkgs/commit/d8b35aa96bd0947f9a924fdde09bd43e3fa91053) | `nanopb: Use protoc from buildPackages`                                       |
| [`5a9fa241`](https://github.com/NixOS/nixpkgs/commit/5a9fa2416dcba73dfdb40a3725fbb9351ba4a64f) | `python3Packages.types-decorator: 0.1.7 -> 5.1.0`                             |
| [`9df16c97`](https://github.com/NixOS/nixpkgs/commit/9df16c97675e625a575ea11bb2d2a5dfe02a556a) | `python3Packages.types-requests: 2.25.9 -> 2.25.10`                           |
| [`00d05bdc`](https://github.com/NixOS/nixpkgs/commit/00d05bdcc611eead029398ac9f0e55b2f861bcdb) | `python3Packages.types-pytz: 2021.1.2 -> 2021.3.0`                            |
| [`fbb57ee0`](https://github.com/NixOS/nixpkgs/commit/fbb57ee06f50c0a9d1c2459b47bbf1494be03e1b) | `python38Packages.python-lsp-server: 1.2.3 -> 1.2.4`                          |
| [`95ce8480`](https://github.com/NixOS/nixpkgs/commit/95ce848041d3c52cb02eb4030e69c0016ebaa643) | `python38Packages.mypy-boto3-s3: 1.18.58 -> 1.18.59`                          |
| [`9a30be12`](https://github.com/NixOS/nixpkgs/commit/9a30be125aabff5948a743a1d2c85418970cf3cf) | `python3Packages.cloudsplaining: fix build`                                   |
| [`8c0421b4`](https://github.com/NixOS/nixpkgs/commit/8c0421b4fc224f8ca514d05b480f1074816a0865) | `python3Packages.policy-sentry: 0.11.17 -> 0.11.18`                           |
| [`b591baa0`](https://github.com/NixOS/nixpkgs/commit/b591baa0595804588d18fa229fb3604c8c990acc) | `python3Packages.ospd: 21.4.3 -> 21.4.4`                                      |
| [`8d7dfcd7`](https://github.com/NixOS/nixpkgs/commit/8d7dfcd7e54246bd44d157b8bbe425b0dfb84025) | `cagebreak: 1.7.1 -> 1.8.0 (#141300)`                                         |
| [`ff7c4a94`](https://github.com/NixOS/nixpkgs/commit/ff7c4a94178254b924280e396ebb2d269ae98ecb) | `toot: 0.27.0 -> 0.28.0 (#141354)`                                            |
| [`975ab7f3`](https://github.com/NixOS/nixpkgs/commit/975ab7f3a02ac0232afe7920a8f7d78fc22d5ccb) | `teamviewer: 15.18.5 -> 15.22.3`                                              |
| [`4fb188e1`](https://github.com/NixOS/nixpkgs/commit/4fb188e1d190f2e08053dba3e2e95fff1e29183a) | `teamviewer: fix 97148 (busybox installed issue)`                             |
| [`b37a1af1`](https://github.com/NixOS/nixpkgs/commit/b37a1af16f8c025ab3421abf83b9aca2246459b1) | `python3Packages.pytradfri: 7.0.6 -> 7.0.7`                                   |
| [`c729c6b1`](https://github.com/NixOS/nixpkgs/commit/c729c6b1ee2fd372347aa3a0d0d491182de076b0) | `python3Packages.millheater: 0.6.1 -> 0.6.2`                                  |
| [`c55bc5bf`](https://github.com/NixOS/nixpkgs/commit/c55bc5bfd3377d54f5b6153d09c033cceadfcc05) | `teamviewer: refactor executable wrapping`                                    |
| [`8087c521`](https://github.com/NixOS/nixpkgs/commit/8087c521fa780ce25509219450fb4a9e7f105051) | `home-assistant: 2021.10.3 -> 2021.10.4`                                      |
| [`889d4fb0`](https://github.com/NixOS/nixpkgs/commit/889d4fb09e38d515e7a668d30d769310a853c189) | `soco-cli: init at 0.4.21`                                                    |
| [`e82eea55`](https://github.com/NixOS/nixpkgs/commit/e82eea55a9ea715cd18080f097a7b06df8d1e0e0) | `python3Packages.rangehttpserver: init at 1.2.0`                              |
| [`6e104e25`](https://github.com/NixOS/nixpkgs/commit/6e104e2517928fd537327ba97eea7a6d8bd02270) | `lightning-pool: 0.5.0-alpha -> 0.5.1-alpha`                                  |
| [`db889eb9`](https://github.com/NixOS/nixpkgs/commit/db889eb9137a859eedfc5b402de84271c0659662) | `teamviewer: 15.15.5 -> 15.18.5`                                              |
| [`ea522953`](https://github.com/NixOS/nixpkgs/commit/ea522953ac928d112334eaa7207f4b41ceb7998f) | `luna-icons: 1.4 -> 1.6`                                                      |
| [`17e2fbf2`](https://github.com/NixOS/nixpkgs/commit/17e2fbf2dcded334556c6c204c4b4a2ca3f10db2) | `alt-ergo: 2.4.0 → 2.4.1`                                                     |
| [`c7b05f54`](https://github.com/NixOS/nixpkgs/commit/c7b05f54dff6c0a5775523035d3ee4111050229d) | `linux/hardened/patches/5.4: 5.4.150-hardened1 -> 5.4.152-hardened1`          |
| [`331bb5fc`](https://github.com/NixOS/nixpkgs/commit/331bb5fcecd7397cbcc86b26b3f014c1294fa78e) | `linux/hardened/patches/5.14: 5.14.9-hardened1 -> 5.14.11-hardened1`          |
| [`42dd2885`](https://github.com/NixOS/nixpkgs/commit/42dd28857d8eaddaca3e36b23f6ee7e3d6f98181) | `linux/hardened/patches/5.10: 5.10.70-hardened1 -> 5.10.72-hardened1`         |
| [`8df94e6d`](https://github.com/NixOS/nixpkgs/commit/8df94e6d31232545ae83cc6cc44f210810234774) | `linux/hardened/patches/4.19: 4.19.208-hardened1 -> 4.19.210-hardened1`       |
| [`6e94404d`](https://github.com/NixOS/nixpkgs/commit/6e94404dc33f7ad6fc491ed6fe6fcc0e5f23611c) | `linux/hardened/patches/4.14: 4.14.248-hardened1 -> 4.14.250-hardened1`       |
| [`86589e8c`](https://github.com/NixOS/nixpkgs/commit/86589e8cd38e73ca655aef4f363cb06b946102bb) | `linux_latest-libre: 18314 -> 18380`                                          |
| [`1d14ebf4`](https://github.com/NixOS/nixpkgs/commit/1d14ebf4140eebcb6a5c956b0a6fe6a513260c30) | `linux: 5.4.151 -> 5.4.152`                                                   |
| [`e2be686e`](https://github.com/NixOS/nixpkgs/commit/e2be686e0a24e791ceb9a3b806aa949102bb344e) | `linux: 5.14.10 -> 5.14.11`                                                   |
| [`2363ead0`](https://github.com/NixOS/nixpkgs/commit/2363ead00306ec8ff8e34ac8b855b4f81af00dfc) | `linux: 5.10.71 -> 5.10.72`                                                   |
| [`04996832`](https://github.com/NixOS/nixpkgs/commit/049968322bc63cccbbebe400dddfed022c103e28) | `linux: 4.9.285 -> 4.9.286`                                                   |
| [`97f30440`](https://github.com/NixOS/nixpkgs/commit/97f30440d94dfa35521108e6fd263053b4710069) | `linux: 4.4.287 -> 4.4.288`                                                   |
| [`4d1cd369`](https://github.com/NixOS/nixpkgs/commit/4d1cd369c8483f1b2c20c461546e13e40427649a) | `linux: 4.19.209 -> 4.19.210`                                                 |
| [`ac66a283`](https://github.com/NixOS/nixpkgs/commit/ac66a2835c4d62a6a85aef9db9264fa0f328b757) | `linux: 4.14.249 -> 4.14.250`                                                 |
| [`1fa11a37`](https://github.com/NixOS/nixpkgs/commit/1fa11a373e221c1aeab52764c095a86ce5911989) | `oh-my-zsh: 2021-10-07 -> 2021-10-11`                                         |
| [`7be5740e`](https://github.com/NixOS/nixpkgs/commit/7be5740e5b84de183afecaf2047c6b4717dceebb) | `python38Packages.sagemaker: 2.59.8 -> 2.60.0`                                |
| [`97e61a07`](https://github.com/NixOS/nixpkgs/commit/97e61a071d950a107f99dd8578ed13f874463649) | `nixos/ssh: take care not to accept empty host key files`                     |
| [`c5686537`](https://github.com/NixOS/nixpkgs/commit/c5686537af10092d7b1be6b4d826a24099621905) | `sirula: unstable->2021-07-11 -> unstable-2021-10-12`                         |
| [`a24951ed`](https://github.com/NixOS/nixpkgs/commit/a24951ed7b834a3be6d59a767f7e69316547484d) | `busybox: 1.33.1 -> 1.34.1; adopt`                                            |
| [`22f83575`](https://github.com/NixOS/nixpkgs/commit/22f83575cb9a5b8d7f04c22e1f6f83cea750f242) | `taskwarrior-tui: 0.13.33 -> 0.13.34`                                         |
| [`a98569d9`](https://github.com/NixOS/nixpkgs/commit/a98569d9d6dcf274d85d910a999e4090cab1211f) | `python3Packages.gvm-tools: disable sending tests`                            |
| [`db3dea9b`](https://github.com/NixOS/nixpkgs/commit/db3dea9b26a10473943b00e2051792ade361679b) | `python3Packages.python-gvm: 21.10.0 -> 21.10.0`                              |
| [`b9942be2`](https://github.com/NixOS/nixpkgs/commit/b9942be29216c419825c8bad9a4442059760f1f9) | `i3: generate doc and man pages`                                              |
| [`467fb8f8`](https://github.com/NixOS/nixpkgs/commit/467fb8f8b3a4c5a527b6d25e4d03ae69afdb39ae) | `python38Packages.google-cloud-securitycenter: 1.6.0 -> 1.7.0`                |
| [`860a61f1`](https://github.com/NixOS/nixpkgs/commit/860a61f1ccf13a49e7f1ab0fa5d2ceb6abb0fd6b) | `img2pdf: 0.4.1 -> 0.4.2`                                                     |
| [`880b84b3`](https://github.com/NixOS/nixpkgs/commit/880b84b37c84d6bd56804fca47f9f91358e1feb8) | `maddy: 0.5.0 -> 0.5.2`                                                       |
| [`ad1aa8ec`](https://github.com/NixOS/nixpkgs/commit/ad1aa8ecf9414a46d20fffe9021f11e7a99926b6) | `python38Packages.google-cloud-error-reporting: 1.2.3 -> 1.3.0`               |
| [`670dcebf`](https://github.com/NixOS/nixpkgs/commit/670dcebf7a104e2e77086644ccbf3f49b57ff33c) | `mutt: 2.1.2 -> 2.1.3`                                                        |
| [`c15eb672`](https://github.com/NixOS/nixpkgs/commit/c15eb6722d48c8b312770beb9ee3afb47fcb819b) | `urlscan: 0.9.6 -> 0.9.7`                                                     |
| [`8e3a5a34`](https://github.com/NixOS/nixpkgs/commit/8e3a5a34049d4dfb469ee7e5f112585fc5c09a30) | `mpop: 1.4.14 -> 1.4.15`                                                      |
| [`609d36dc`](https://github.com/NixOS/nixpkgs/commit/609d36dc2fdbcb3e2342f2839b551da2a69affbf) | `python3Packages.rxv: 0.6.0 -> 0.7.0`                                         |
| [`3ce9b827`](https://github.com/NixOS/nixpkgs/commit/3ce9b827d6762633978bde0a323724e9b558898c) | `matrix-appservice-slack: 1.8.0 -> 1.9.0`                                     |
| [`e0fcc868`](https://github.com/NixOS/nixpkgs/commit/e0fcc8686541476cabfa103847cee4902c3968b3) | `home-assistant: update component-packages`                                   |
| [`6d71998e`](https://github.com/NixOS/nixpkgs/commit/6d71998e459599cf13059587eae68c42407e9246) | `python3Packages.pytautulli: init at 21.10.0`                                 |
| [`6ddd8a83`](https://github.com/NixOS/nixpkgs/commit/6ddd8a833e3feafb42d0682aceae26cb6557b7d1) | `python38Packages.google-cloud-automl: 2.4.2 -> 2.5.0`                        |
| [`4a26e36f`](https://github.com/NixOS/nixpkgs/commit/4a26e36f36b1692dfac50714f335d74ca0e2a917) | `python3Packages.aiomusiccast: 0.9.2 -> 0.10.0`                               |
| [`95884147`](https://github.com/NixOS/nixpkgs/commit/958841476247089d81cd662619dce303e119b81c) | `python38Packages.google-cloud-container: 2.8.1 -> 2.9.0`                     |
| [`bdd81fa0`](https://github.com/NixOS/nixpkgs/commit/bdd81fa05670fd84ccc7a2f3ee9a38d3aa9e5a40) | `kopia: 0.8.4 -> 0.9.0`                                                       |
| [`18c73db6`](https://github.com/NixOS/nixpkgs/commit/18c73db67723e4196924c62433fcdaa31e37a507) | `python38Packages.azure-mgmt-rdbms: 9.1.0 -> 10.0.0`                          |
| [`edbfad1c`](https://github.com/NixOS/nixpkgs/commit/edbfad1cd5e0742b8e25ed69c67cda494b53fc5d) | `electron_12: 12.2.1 -> 12.2.2`                                               |
| [`a835cbba`](https://github.com/NixOS/nixpkgs/commit/a835cbba0df8c4a85fc42ba2f22c36895fb18bbe) | `electron_13: 13.5.1 -> 13.5.2`                                               |
| [`7cea9253`](https://github.com/NixOS/nixpkgs/commit/7cea9253efc82c7638e24b3e9588e78a93f6aabe) | `python38Packages.google-cloud-speech: 2.9.3 -> 2.10.0`                       |
| [`ac925487`](https://github.com/NixOS/nixpkgs/commit/ac925487b9b08357dfbacdfe330fe3bcf3d1213f) | `python38Packages.azure-multiapi-storage: 0.6.2 -> 0.7.0`                     |
| [`f1236599`](https://github.com/NixOS/nixpkgs/commit/f12365990654454869b398dde4f76495aa73d6fb) | `gitRepo: 2.17 -> 2.17.1`                                                     |
| [`7662f6dd`](https://github.com/NixOS/nixpkgs/commit/7662f6dd21e63deb3fe77b4651fe015d37ec37bb) | `imagemagick: build with libraw`                                              |
| [`ddf8d9a0`](https://github.com/NixOS/nixpkgs/commit/ddf8d9a0d4f19bfe5d009ac15af53aea4abfeb1d) | `pythonPackages.pysam: 0.16.0.1 -> 0.17.0`                                    |
| [`24d3cd81`](https://github.com/NixOS/nixpkgs/commit/24d3cd8152f5b8fed8c2fc2fbe65e24a32513365) | `anytype: 0.19.0 -> 0.20.2`                                                   |
| [`c1ecf6d2`](https://github.com/NixOS/nixpkgs/commit/c1ecf6d2b4b0d23409b35025958d103546e74fc8) | `gtkwave: 3.3.110 -> 3.3.111`                                                 |
| [`cd78f8e7`](https://github.com/NixOS/nixpkgs/commit/cd78f8e761e2d88bfb71f97565656e3a0cb370c5) | `krita: 4.4.7 -> 4.4.8; krita-beta: init at 5.0.0-beta1 (#139476)`            |
| [`1b4cdac3`](https://github.com/NixOS/nixpkgs/commit/1b4cdac33ea8335d6593ff47a46305dc78ea53c4) | `podman: remove darwin wrapper`                                               |
| [`02a1a2b3`](https://github.com/NixOS/nixpkgs/commit/02a1a2b3c81a8a93bbc75046804cfe4e90f1bced) | `samtools: 1.11 -> 1.13`                                                      |
| [`292a1d63`](https://github.com/NixOS/nixpkgs/commit/292a1d631000c0c40686b15a972615b82970f413) | `htslib: 1.11 -> 1.13`                                                        |
| [`9f351d0b`](https://github.com/NixOS/nixpkgs/commit/9f351d0ba765a7071cdf20638967234525c0e2c7) | `diffoscope: 186 -> 187`                                                      |
| [`a3270eb0`](https://github.com/NixOS/nixpkgs/commit/a3270eb062a93bc780b7ee923df6c6a70b5a25b8) | `linuxPackages.perf: fix objdump lookup`                                      |
| [`95194b0d`](https://github.com/NixOS/nixpkgs/commit/95194b0dff87481d22e78b5796542f6f0c0aa4da) | `yggdrasil: add genkeys utility`                                              |
| [`36f25f27`](https://github.com/NixOS/nixpkgs/commit/36f25f27ebef78793d0ff70061ddf63181afe652) | `zesarux: init at 10.0`                                                       |
| [`9d09793c`](https://github.com/NixOS/nixpkgs/commit/9d09793cab9e323575821a2b6fd1fcc19a2c8965) | `python3Packages.asyncwhois: 0.4.0 -> 0.4.1`                                  |
| [`780bfc11`](https://github.com/NixOS/nixpkgs/commit/780bfc11e99a42da1fb9926604d5ac7a42fa2b94) | `python3Packages.qualysclient: init at 0.0.4.8.1`                             |
| [`18ad855d`](https://github.com/NixOS/nixpkgs/commit/18ad855d654fcdf353506df4c85cbae097a67304) | `avizo: init at unstable-2021-07-21`                                          |
| [`e148619e`](https://github.com/NixOS/nixpkgs/commit/e148619e37ecb3648bebb8912a1d61b08c0d86c5) | `hamlib: support cross-compilation, cleanup`                                  |
| [`919226b1`](https://github.com/NixOS/nixpkgs/commit/919226b1d8a9f623218bfb497e434a979c2bfd36) | `httpx: 1.1.2 -> 1.1.3`                                                       |
| [`390c8022`](https://github.com/NixOS/nixpkgs/commit/390c80228c26e4a5a2b67c58b40cefb62d3abad6) | `ansible_2_9: 2.9.26 -> 2.9.27`                                               |
| [`8be8e6da`](https://github.com/NixOS/nixpkgs/commit/8be8e6da4e6df079be93715738c3f6e26571182c) | `ansible_2_10: 2.10.14 -> 2.10.15`                                            |
| [`7ec67dc0`](https://github.com/NixOS/nixpkgs/commit/7ec67dc03c2ce8a1591643f3cd8b08635b125a27) | `ansible_2_11: 2.11.5 -> 2.11.6`                                              |
| [`895d09aa`](https://github.com/NixOS/nixpkgs/commit/895d09aa3a6100fa1e8e66ddcc825bbde8e489ff) | `linux_lqx: 5.14.9 -> 5.14.11`                                                |
| [`0b4c16d2`](https://github.com/NixOS/nixpkgs/commit/0b4c16d22904738640cb7b8b5d7330c2d4749f2e) | `hushboard: init at unstable-2021-03-17`                                      |
| [`5323733f`](https://github.com/NixOS/nixpkgs/commit/5323733f7b44d2cea0fad8840f5201a01ae77a0e) | `ghostscript: set meta.mainProgram`                                           |
| [`3096f0a6`](https://github.com/NixOS/nixpkgs/commit/3096f0a6026a5086070d31fb1dba50a7b38c100c) | `home-assistant: 2021.10.2 -> 2021.10.3`                                      |
| [`ffbe2566`](https://github.com/NixOS/nixpkgs/commit/ffbe2566c45e8a416b3f70b8a70c7e624317485c) | `python3Packages.zeroconf: 0.36.7 -> 0.36.8`                                  |