### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0478f8b360288a4be8c71bf11e42fcaf09b8b773",
-        "sha256": "0ajd2lzsjxw2zdc35a5xw8ci0k5vizj63xvxnpya2m45wr9dn5rj",
+        "rev": "06bc193d23e65790f4c37b88d33ddee3363802f6",
+        "sha256": "1cp8lc6vxyz8zcsc4db38aqxn0xvshbyhd0q4605wf68mgnjhwi4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0478f8b360288a4be8c71bf11e42fcaf09b8b773.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/06bc193d23e65790f4c37b88d33ddee3363802f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`c0f60149`](https://github.com/NixOS/nixpkgs/commit/c0f60149708fb9bb8014fcc8b03fc25ea10f9b27) | `ocamlPackages.ocaml-freestanding: 0.6.4 → 0.6.5`                                             |
| [`5f7e675c`](https://github.com/NixOS/nixpkgs/commit/5f7e675c455d17564eff46911cee4b602c1b5e63) | `nixos/libvirtd: add qemuOvmfPackage option`                                                  |
| [`e6cd387e`](https://github.com/NixOS/nixpkgs/commit/e6cd387e0510f6093fec3739706d9d92dd93256c) | `python3Packages.browser-cookie3: add pythonImportsCheck`                                     |
| [`1995c1ce`](https://github.com/NixOS/nixpkgs/commit/1995c1ce4b60d0507318e05121f0af5a77adb7ba) | `python3Packages.asyncssh: disable TestSKAuthCTAP2 tests`                                     |
| [`280e7b93`](https://github.com/NixOS/nixpkgs/commit/280e7b93bef612f74cb5110e3afad4f90818c717) | `unbound: enable more features`                                                               |
| [`79ffee21`](https://github.com/NixOS/nixpkgs/commit/79ffee21c5395c9e71b1a7456f5ee60942177d44) | `python3Packages.pyintesishome: 1.8.0 -> 1.8.1`                                               |
| [`cb1b8eb4`](https://github.com/NixOS/nixpkgs/commit/cb1b8eb419fb474e181d206366447c9f729dd0c2) | `exploitdb: 2021-10-15 -> 2021-10-16`                                                         |
| [`d883b616`](https://github.com/NixOS/nixpkgs/commit/d883b616ef0e4ce5fcabf7152aa58264e3c47cb6) | `jetbrains: update`                                                                           |
| [`6e8bde44`](https://github.com/NixOS/nixpkgs/commit/6e8bde44448205b05a769f75624584343961204f) | `python38Packages.mypy-boto3-s3: 1.18.62 -> 1.18.63`                                          |
| [`7f8d276a`](https://github.com/NixOS/nixpkgs/commit/7f8d276a8a2be2b698cf1c0e30505b5ea0c99027) | `kn: init at 0.26.0 (#141928)`                                                                |
| [`4973ffc8`](https://github.com/NixOS/nixpkgs/commit/4973ffc800e9ca08e36772332c23505e51cd31a8) | `zettlr: 1.8.9 -> 2.0.0`                                                                      |
| [`c1f51554`](https://github.com/NixOS/nixpkgs/commit/c1f515547109a7e1845120449676ba6aa9a78fe9) | `nixos/networking: support FOU encapsulation for sits`                                        |
| [`f29ea2d1`](https://github.com/NixOS/nixpkgs/commit/f29ea2d15d833494f7e97e0231b03ca70a8e7db4) | `nixos/networking: add foo-over-udp endpoint support`                                         |
| [`84e726be`](https://github.com/NixOS/nixpkgs/commit/84e726be4724435fc8531d698a379199d5c9eff6) | `dbqn: 0.pre+unstable=2021-10-05 -> 0.pre+date=2021-10-08`                                    |
| [`504fff7a`](https://github.com/NixOS/nixpkgs/commit/504fff7a3b6e2b33ab1664e8671fbe89d6fb9ceb) | `dapl: 0.2.0+unstable=2021-06-30 -> 0.2.0+date=2021-10-16`                                    |
| [`eebfe719`](https://github.com/NixOS/nixpkgs/commit/eebfe7199d9e543acea19de4af15a91ab7774e7c) | `trellis: Added installCheckPhase that ensures database is available and updated maintainers` |
| [`56c31c1b`](https://github.com/NixOS/nixpkgs/commit/56c31c1b13242a4013203e180411b3744ca3984a) | `trellis: Revert removal of CMAKE_INSTALL_DATADIR`                                            |
| [`20c78da4`](https://github.com/NixOS/nixpkgs/commit/20c78da41fd1185b521487b0296a8d014a3e0401) | `kubernetes-helmPlugins.helm-git: init at 0.10.0`                                             |
| [`d7b844ef`](https://github.com/NixOS/nixpkgs/commit/d7b844ef82c159b30ba3b5fd7a2299cc748997b8) | `bubblewrap: 0.4.1 -> 0.5.0`                                                                  |
| [`a2004d37`](https://github.com/NixOS/nixpkgs/commit/a2004d37a3c2ef4380097a8a8e28632ec395ec78) | `lmms: build using fluidsynth 2.x`                                                            |
| [`a21416e5`](https://github.com/NixOS/nixpkgs/commit/a21416e5a92704eb6270f20dfb596c94f7f48e49) | `vimPlugins.nvim-lsp-ts-utils: init at 2021-10-03`                                            |
| [`d3e92322`](https://github.com/NixOS/nixpkgs/commit/d3e9232242f5276a385a2b03837651da54422e30) | `vimPlugins: update`                                                                          |
| [`85d1b34f`](https://github.com/NixOS/nixpkgs/commit/85d1b34f320e500b14a1699fc035faac2749cf33) | `linuxPackages.nvidia_x11_beta: 470.42.01 -> 495.29.05`                                       |
| [`0773baf0`](https://github.com/NixOS/nixpkgs/commit/0773baf0beb83f986b1b98a0eede495a3c8a750f) | `python38Packages.aiosignal: 1.1.2 -> 1.2.0`                                                  |
| [`f33e326e`](https://github.com/NixOS/nixpkgs/commit/f33e326e4029d2455d1a2a040d6e04696b0b0ff1) | `highlight: make manpage compression reproducible`                                            |
| [`9b3ef21b`](https://github.com/NixOS/nixpkgs/commit/9b3ef21bff420b87aa00418dbe1037ed5f5fd322) | `signal-desktop: 5.19.0 -> 5.20.0`                                                            |
| [`20441457`](https://github.com/NixOS/nixpkgs/commit/20441457d94a1344a86aa236814fa456feec72eb) | `sqlfluff: 0.6.8 -> 0.7.0`                                                                    |
| [`cb8fcfa3`](https://github.com/NixOS/nixpkgs/commit/cb8fcfa3e65b169cd94709fff54dd4ea55d24db7) | `highlight: fix cross-platform build`                                                         |
| [`78d619d9`](https://github.com/NixOS/nixpkgs/commit/78d619d9d5a0c9413bcf217e7b9cf3982541ad10) | `dapl, dapl-native: fix`                                                                      |
| [`b0581c26`](https://github.com/NixOS/nixpkgs/commit/b0581c2699cf4f4fb7da2098385372739d4d8955) | `chromiumDev: Fix the build`                                                                  |
| [`765142f3`](https://github.com/NixOS/nixpkgs/commit/765142f3154a81130d4ebc89e3a8aaf005ad020c) | `python3Packages.frozenlist: 1.1.1 -> 1.2.0`                                                  |
| [`9889c07e`](https://github.com/NixOS/nixpkgs/commit/9889c07eb3c6919eb1f71fbbd871e5166aa71ec4) | `ddnet: init at 15.5.4`                                                                       |
| [`397b6492`](https://github.com/NixOS/nixpkgs/commit/397b6492832866fb4d4d7e4ea837376acc14512d) | `luaPackages.luarocks-3_7: init so that the reverted update can be accessed if desired`       |
| [`5c93a778`](https://github.com/NixOS/nixpkgs/commit/5c93a7780a5f9e47f534e7c726a65b72f4b9d2ce) | `Revert "luarocks: 3.2.1 -> 3.7.0"`                                                           |
| [`1d93a080`](https://github.com/NixOS/nixpkgs/commit/1d93a080a6ad6cffb2b7ac38b8e86dd46937a543) | `lua: add conditional to use linux-readline as the plat on 5.4+`                              |
| [`e8499098`](https://github.com/NixOS/nixpkgs/commit/e849909813eddce351baa0429a98299da80c77e6) | `alpine: 2.24 → 2.25`                                                                         |
| [`3c6a46cf`](https://github.com/NixOS/nixpkgs/commit/3c6a46cfc970ac21cd1b3ce2a1394075a3af969a) | `osu-lazer: 2021.1006.1 -> 2021.1016.0`                                                       |
| [`16c505e8`](https://github.com/NixOS/nixpkgs/commit/16c505e87e4724a4488c5a1a96316374c6dc3ab3) | `metals: 0.10.6 → 0.10.7`                                                                     |
| [`3fe3c640`](https://github.com/NixOS/nixpkgs/commit/3fe3c640e827bb282bbf336db6b607fac2621499) | `jitsi-meet: 1.0.5307 -> 1.0.5415`                                                            |
| [`1ea63956`](https://github.com/NixOS/nixpkgs/commit/1ea6395610212ea8c54bd39560eebc0f33d7a76c) | `ms-python.python: fix #139813 and #137314 (lttng-ust and libstdc++ errors) (#140564)`        |
| [`18d24771`](https://github.com/NixOS/nixpkgs/commit/18d24771da3a19113122ba961b4b206613883f60) | `flitter: init at unstable-2020-10-05`                                                        |
| [`0ad041e5`](https://github.com/NixOS/nixpkgs/commit/0ad041e5bcf5358ba100f806e2e925ef5c7be7bf) | `ocamlPackages.color: init at 0.2.0`                                                          |
| [`0eae36de`](https://github.com/NixOS/nixpkgs/commit/0eae36de63a1021b4ab48b35281655530d4339ea) | `battop: remove`                                                                              |
| [`3f9e478d`](https://github.com/NixOS/nixpkgs/commit/3f9e478db130170829d5b9143c1e653e662f3847) | `jitsi-videobridge: 2.1-551-g2ad6eb0b -> 2.1-570-gb802be83`                                   |
| [`e8b8dd13`](https://github.com/NixOS/nixpkgs/commit/e8b8dd13e0d867f8753f89946dbc4bc614000368) | `jitsi-meet-prosody: 1.0.5307 -> 1.0.5415`                                                    |
| [`c8e9d945`](https://github.com/NixOS/nixpkgs/commit/c8e9d945428669c4de5d3889bd9ae9e9f5943368) | `python38Packages.keepkey: 6.7.0 -> 7.2.1`                                                    |
| [`5ca1a1a2`](https://github.com/NixOS/nixpkgs/commit/5ca1a1a2c167f2543cd1349512d8f3afb34ef1ce) | `python38Packages.cucumber-tag-expressions: 4.0.2 -> 4.1.0`                                   |
| [`319f7d2a`](https://github.com/NixOS/nixpkgs/commit/319f7d2aa45eff6e5220750fd6b68ab62a1c4010) | `python38Packages.azure-mgmt-compute: 23.0.0 -> 23.1.0`                                       |
| [`55d4dc8f`](https://github.com/NixOS/nixpkgs/commit/55d4dc8f3eaf7e0bd7d929ed6dba30e30646b19b) | `python38Packages.gsd: 2.4.2 -> 2.5.0`                                                        |
| [`afa3174c`](https://github.com/NixOS/nixpkgs/commit/afa3174c73e1ee43e4b6e41b0862c9f30bc0d315) | `python38Packages.nunavut: 1.5.0 -> 1.5.1`                                                    |
| [`b47182ff`](https://github.com/NixOS/nixpkgs/commit/b47182ff8cb7bbc9402813823784bdaa4628b2ed) | `python38Packages.google-cloud-iam-logging: 0.1.3 -> 0.2.0`                                   |
| [`6e58a09e`](https://github.com/NixOS/nixpkgs/commit/6e58a09e52a1fa8be4efc9fe201a6bccf3d5b75d) | `python38Packages.inifile: 0.3 -> 0.4.1`                                                      |
| [`33bc6f87`](https://github.com/NixOS/nixpkgs/commit/33bc6f87068d4bbc843881b6581d8a07e4a424aa) | `docker-compose2: init at 2.0.1 (#141366)`                                                    |
| [`5d1532c5`](https://github.com/NixOS/nixpkgs/commit/5d1532c5aa434a0903953003a891e61302d8ac57) | `python38Packages.pulsectl: 21.9.1 -> 21.10.4`                                                |
| [`03ab641a`](https://github.com/NixOS/nixpkgs/commit/03ab641a3a728344145bfc8860ef882bcb242449) | `python38Packages.mockupdb: 1.8.0 -> 1.8.1`                                                   |
| [`fb11d51e`](https://github.com/NixOS/nixpkgs/commit/fb11d51e280da7e81b34d78879171edbc4305769) | `hubstaff: 1.6.2-b5029032 -> 1.6.2-328c666b`                                                  |
| [`fa17503c`](https://github.com/NixOS/nixpkgs/commit/fa17503ced275e068d68a20fb174bd54fa4a1498) | `python38Packages.lightgbm: 3.2.1 -> 3.3.0`                                                   |
| [`c2572160`](https://github.com/NixOS/nixpkgs/commit/c25721601dbe5c0d2c2436204ba1f391f71ffa20) | `python38Packages.stripe: 2.60.0 -> 2.61.0`                                                   |
| [`a89b31ac`](https://github.com/NixOS/nixpkgs/commit/a89b31ac1c846ceaf9d7bd7476a8f4f7c3d4aac3) | `python38Packages.azure-mgmt-datafactory: 1.1.0 -> 2.0.0`                                     |
| [`b7765fee`](https://github.com/NixOS/nixpkgs/commit/b7765fee5130598f3be0214021a35ef3935296a4) | `python38Packages.nltk: 3.6.4 -> 3.6.5`                                                       |
| [`9eff77bc`](https://github.com/NixOS/nixpkgs/commit/9eff77bc60f65287e65fa1a8aff533cd8fe4d867) | `python38Packages.limnoria: 2021.07.21 -> 2021.10.9`                                          |
| [`c49cde62`](https://github.com/NixOS/nixpkgs/commit/c49cde62f00c0f1d114c38b9e6f26ffb05293573) | `python38Packages.types-protobuf: 3.17.5 -> 3.18.0`                                           |
| [`ccfd9f50`](https://github.com/NixOS/nixpkgs/commit/ccfd9f50d487cc101adb31cb4031f590027031cd) | `python38Packages.annexremote: 1.4.5 -> 1.6.0`                                                |
| [`8bcfa5ed`](https://github.com/NixOS/nixpkgs/commit/8bcfa5edfb242928a51e9449ac326be85703614f) | `python38Packages.django-storages: 1.12 -> 1.12.1`                                            |
| [`1ec3f619`](https://github.com/NixOS/nixpkgs/commit/1ec3f619742053018b2c59dc3733369b236bd603) | `python38Packages.sagemaker: 2.60.0 -> 2.63.0`                                                |
| [`8b475f18`](https://github.com/NixOS/nixpkgs/commit/8b475f1880036a49911ced43beaf13438a75b5e8) | `python38Packages.pynndescent: 0.5.4 -> 0.5.5`                                                |
| [`78d3d137`](https://github.com/NixOS/nixpkgs/commit/78d3d137ea1c6f6602e4103fdb072ba73ec0aa54) | `python38Packages.django_modelcluster: 5.1 -> 5.2`                                            |
| [`0fa14d32`](https://github.com/NixOS/nixpkgs/commit/0fa14d32ec13ffcaaa78a1c888ac01a951cea0a2) | `python38Packages.awkward: 1.5.0 -> 1.5.1`                                                    |
| [`c267b390`](https://github.com/NixOS/nixpkgs/commit/c267b3908156ceff4e6b8fcb48ed566ffc2ae619) | `python38Packages.azure-identity: 1.6.1 -> 1.7.0`                                             |
| [`0be1a95e`](https://github.com/NixOS/nixpkgs/commit/0be1a95e5ad32c153a9ccd48675a420b5f01d4dc) | `python38Packages.strictyaml: 1.4.4 -> 1.5.0`                                                 |
| [`3faf5493`](https://github.com/NixOS/nixpkgs/commit/3faf54932cefd69d4e34e62ad614192249766962) | `gitRepo: 2.17.1 -> 2.17.2`                                                                   |
| [`aa6cb73f`](https://github.com/NixOS/nixpkgs/commit/aa6cb73f5e4bf621fc8114bb7f067064cad8e4e8) | `python38Packages.env-canada: 0.5.13 -> 0.5.14`                                               |
| [`05d9c4e3`](https://github.com/NixOS/nixpkgs/commit/05d9c4e3b61e4b805439e14f42aba7adbb5ab12c) | `python38Packages.mypy-boto3-s3: 1.18.60 -> 1.18.62`                                          |
| [`1416be78`](https://github.com/NixOS/nixpkgs/commit/1416be7893f77ba2de36c5624103d8bdc93f830d) | `python38Packages.pymetar: 1.3 -> 1.4`                                                        |
| [`682e7efa`](https://github.com/NixOS/nixpkgs/commit/682e7efafc3aff5f4436ed8d8b4b4cacea94b976) | `python38Packages.intensity-normalization: 2.0.3 -> 2.1.0`                                    |
| [`8c5e07ca`](https://github.com/NixOS/nixpkgs/commit/8c5e07ca9d491a8bee1e6b343679891ac574d09e) | `python38Packages.hg-evolve: 10.3.3 -> 10.4.0`                                                |
| [`980d3e1e`](https://github.com/NixOS/nixpkgs/commit/980d3e1e68171e3ec99d514b695bca95f7ae4931) | `python38Packages.pyvmomi: 7.0.2 -> 7.0.3`                                                    |
| [`2dc8282f`](https://github.com/NixOS/nixpkgs/commit/2dc8282f91728ca66ab6fa21504da0e7000b2c57) | `python38Packages.python-rapidjson: 1.4 -> 1.5`                                               |
| [`08c5aa32`](https://github.com/NixOS/nixpkgs/commit/08c5aa32e4ca73ae614912db0557c8839e727bef) | `vlc: remove live555 dependency on 32-bit ARM (#141215)`                                      |
| [`1daab6c7`](https://github.com/NixOS/nixpkgs/commit/1daab6c7339f072293e9d77e80c7d558870a848a) | `python38Packages.pynput: 1.7.3 -> 1.7.4`                                                     |
| [`23d28a5c`](https://github.com/NixOS/nixpkgs/commit/23d28a5caa740007029a99f97fbf4e6391359f47) | `python38Packages.ibm-cloud-sdk-core: 3.11.3 -> 3.12.0`                                       |
| [`de8d0982`](https://github.com/NixOS/nixpkgs/commit/de8d09829e32e7531df7f16f7e97f67efe4ea1f9) | `python38Packages.robotframework: 4.1.1 -> 4.1.2`                                             |
| [`42db6197`](https://github.com/NixOS/nixpkgs/commit/42db619720dc144f495d409a7b1ebd1f1550a382) | `python38Packages.progressbar2: 3.54.0 -> 3.55.0`                                             |
| [`4df3bf48`](https://github.com/NixOS/nixpkgs/commit/4df3bf48ad3103129907ca09a338815443c66cdd) | `python38Packages.pytwitchapi: 2.4.2 -> 2.5.0`                                                |
| [`218ea9f2`](https://github.com/NixOS/nixpkgs/commit/218ea9f22366a1040fe371847dd369133192707e) | `flexget: 3.1.138 -> 3.1.139`                                                                 |
| [`24fceb4a`](https://github.com/NixOS/nixpkgs/commit/24fceb4a931e60ef5d66e8b6545727664841703e) | `svdtools: init at 0.1.20`                                                                    |
| [`ce036aad`](https://github.com/NixOS/nixpkgs/commit/ce036aad8e7f3ae46d2e60dd04a877896fc1083a) | `python3Packages.braceexpand: init at 0.1.7`                                                  |
| [`b0ed9c83`](https://github.com/NixOS/nixpkgs/commit/b0ed9c8372686a513c947c204956e7a28e7e7147) | `tracker: patch failing test due to float comparison`                                         |
| [`d4c2c9c9`](https://github.com/NixOS/nixpkgs/commit/d4c2c9c960e34117e76614f7e927905b54ed589a) | `vouch-proxy: 0.34.1 -> 0.35.1`                                                               |
| [`29c8e91c`](https://github.com/NixOS/nixpkgs/commit/29c8e91c5dc5fcd510e00ebf0611481458b4d31d) | `macdylibbundler: 20180825 -> 1.0.0`                                                          |
| [`96e03882`](https://github.com/NixOS/nixpkgs/commit/96e038820c4bde374bf484886b695f169292dc2f) | `julius: 1.6.0 -> 1.7.0`                                                                      |
| [`8960e6bc`](https://github.com/NixOS/nixpkgs/commit/8960e6bc7457cc1850ff8013750ca7c19c8a8797) | `python38Packages.miniaudio: 1.44 -> 1.45`                                                    |
| [`5f0d9180`](https://github.com/NixOS/nixpkgs/commit/5f0d9180ac7656c3ad6a40939ad2258f7cd9de0c) | `tectonic: 0.7.0 -> 0.8.0`                                                                    |
| [`a6f7fdfe`](https://github.com/NixOS/nixpkgs/commit/a6f7fdfe0875287fa6b25b009f71a8497cdaedc4) | `vale: 2.10.6 -> 2.11.2`                                                                      |
| [`92daf01d`](https://github.com/NixOS/nixpkgs/commit/92daf01de69c4679f09cdcfd9e276c45d2cce8d3) | `tlp: 1.3.1 -> 1.4.0`                                                                         |
| [`5c16ebad`](https://github.com/NixOS/nixpkgs/commit/5c16ebad93bf4fa481855797d4edc0efff0ae31d) | `pgformatter: 5.0 -> 5.1`                                                                     |
| [`0b92261d`](https://github.com/NixOS/nixpkgs/commit/0b92261d6a9dc256418e3dc0cde67b52b560a686) | `OVMF: add TPM2 support flags`                                                                |
| [`dfbd20a1`](https://github.com/NixOS/nixpkgs/commit/dfbd20a16e7e488765e8df2dda1f2411858d7c52) | `ttyper: 0.2.5 -> 0.3.0`                                                                      |
| [`a8498f08`](https://github.com/NixOS/nixpkgs/commit/a8498f08bf29c129d91978aaedf60877f0047553) | `linux-libre: unbreak`                                                                        |
| [`42dcdc2c`](https://github.com/NixOS/nixpkgs/commit/42dcdc2c3adcc1d13d5c2dddaa0792482efe8a1e) | `openssl: Fix build configuration for riscv64-linux`                                          |
| [`982ffc81`](https://github.com/NixOS/nixpkgs/commit/982ffc81758167705f08f073ae1fe85002345bdd) | `maintainers: add sirseruju`                                                                  |
| [`98921606`](https://github.com/NixOS/nixpkgs/commit/98921606a57ac043350b2cc77ac201b67cb19bb9) | `gosec: 2.8.1 -> 2.9.1`                                                                       |
| [`8e394b85`](https://github.com/NixOS/nixpkgs/commit/8e394b8533233a53d4e6074f079cbb34b43bbcb4) | `licenses: add CAPEC`                                                                         |
| [`37771f6f`](https://github.com/NixOS/nixpkgs/commit/37771f6fe020e62f07102fc99bc18dfd17929448) | `python37Packages.flake8: don't run tests if older than python3.8`                            |
| [`b29418ad`](https://github.com/NixOS/nixpkgs/commit/b29418add8e81cdc2d173e44239895ea493277c0) | `neomutt: 20210205 -> 20211015`                                                               |
| [`d88cc970`](https://github.com/NixOS/nixpkgs/commit/d88cc970ce7d316993bb1d59f717adecb08f6ab9) | `agebox: 0.6.0 -> 0.6.1`                                                                      |
| [`5bb74548`](https://github.com/NixOS/nixpkgs/commit/5bb74548faf16829e913ab88865abca4484a02d5) | `ike-scan: 1.9.4 -> 1.9.5`                                                                    |
| [`41eee0ef`](https://github.com/NixOS/nixpkgs/commit/41eee0ef7a2e226ed1a07435e517f5c125d90a5c) | `krane: fix darwin build`                                                                     |
| [`abbb7c6e`](https://github.com/NixOS/nixpkgs/commit/abbb7c6e60b60f2a516b8a69c45c5b8bb415cc0f) | `aws-sdk-cpp: 1.8.130 -> 1.9.121`                                                             |
| [`4786f9e8`](https://github.com/NixOS/nixpkgs/commit/4786f9e8453cf5a632a91c14a1940ad5029735a7) | `aws-crt-cpp: init at 0.17.0`                                                                 |
| [`095ababa`](https://github.com/NixOS/nixpkgs/commit/095ababaf6574f29b5611cbe577502729e86f149) | `aws-c-mqtt: init at 0.7.8`                                                                   |
| [`b01ae7ae`](https://github.com/NixOS/nixpkgs/commit/b01ae7ae3550d60672d123714af822185caec088) | `aws-c-s3: init at 0.1.27`                                                                    |
| [`bc62bf52`](https://github.com/NixOS/nixpkgs/commit/bc62bf52e34f59ad811eaba06caca8a7f0821f5e) | `aws-c-auth: init at 0.6.4`                                                                   |
| [`1c2ca77d`](https://github.com/NixOS/nixpkgs/commit/1c2ca77d7477cc369d0faa08ee9695d16276c804) | `aws-c-http: init at 0.6.7`                                                                   |
| [`ff6afebd`](https://github.com/NixOS/nixpkgs/commit/ff6afebdb398fa601a8a1b3fc68b1417efe2dc5e) | `aws-c-compression: init at 0.2.14`                                                           |
| [`530cd8c3`](https://github.com/NixOS/nixpkgs/commit/530cd8c3ccdef6c2bbf31ac1fa8c1f94d773ad57) | `aws-c-io: 0.10.5 -> 0.10.9`                                                                  |
| [`310e86a8`](https://github.com/NixOS/nixpkgs/commit/310e86a8341e68d45cacd94201704a95104b494e) | `aws-c-common: 0.6.9 -> 0.6.12, cleanup`                                                      |
| [`a1156ceb`](https://github.com/NixOS/nixpkgs/commit/a1156ceb9714379d7ecad12c92cd266048a6882f) | `python3Packages.aioridwell: init at 0.2.0`                                                   |
| [`1b58f827`](https://github.com/NixOS/nixpkgs/commit/1b58f82701cb1239b733fb9535dbae550a098942) | `python3Packages.titlecase: enable tests`                                                     |
| [`7ae7179d`](https://github.com/NixOS/nixpkgs/commit/7ae7179debd00dee32300f5d71d8b43c6aceef93) | `pulumi-bin: fix wrong hashes`                                                                |
| [`36f981da`](https://github.com/NixOS/nixpkgs/commit/36f981dad845b9b8b99ba63f17f4c2385caf79a2) | `terragrunt: 0.33.0 -> 0.35.1`                                                                |
| [`08d4bb6e`](https://github.com/NixOS/nixpkgs/commit/08d4bb6e7ab73dde59334c72389b3dc23b20ced5) | `linux: 5.4.152 -> 5.4.153`                                                                   |
| [`39189bc4`](https://github.com/NixOS/nixpkgs/commit/39189bc4f0135bb7fb6787018bbd69393cabcaaa) | `linux: 5.14.11 -> 5.14.12`                                                                   |
| [`4f59512c`](https://github.com/NixOS/nixpkgs/commit/4f59512c0c9fc3e5e176d0197b14d6a32cfb13cf) | `linux: 5.10.72 -> 5.10.73`                                                                   |
| [`821d8339`](https://github.com/NixOS/nixpkgs/commit/821d8339f80c2664d6157a453e0d194dffcef61e) | `linux: 4.19.210 -> 4.19.211`                                                                 |
| [`4329cbdc`](https://github.com/NixOS/nixpkgs/commit/4329cbdcc43b5c56a934fcaae9aebb9444f3e902) | `knot-resolver: 5.4.1 -> 5.4.2`                                                               |
| [`e38accb2`](https://github.com/NixOS/nixpkgs/commit/e38accb2b0e6b3d2d0ed8a5c642661bbcbfb3d4f) | `wasm-bindgen-cli: 0.2.75 -> 0.2.78`                                                          |
| [`d3ce8e4c`](https://github.com/NixOS/nixpkgs/commit/d3ce8e4c6ce3de3d52ff9b16dcb29d04ceb2aa2e) | `git-privacy: init at 2.1.0`                                                                  |
| [`f21d29b0`](https://github.com/NixOS/nixpkgs/commit/f21d29b0bcabd708637181792b87a6de0e821ca7) | `python3Packages.git-filter-repo: init at 2.33.0`                                             |
| [`359481f2`](https://github.com/NixOS/nixpkgs/commit/359481f255411ce6c951a981a7ab042f438332c7) | `s2n-tls: cleanup`                                                                            |
| [`ee165d92`](https://github.com/NixOS/nixpkgs/commit/ee165d92222b96a4a989abc6c37ac9f3f4a90d18) | `python38Packages.browser-cookie3: 0.12.1 -> 0.13.0`                                          |
| [`b7799ce5`](https://github.com/NixOS/nixpkgs/commit/b7799ce5b0f1dd0ca72a5de04959511c9c692094) | `sord: support cross-compilation`                                                             |
| [`d2938964`](https://github.com/NixOS/nixpkgs/commit/d2938964df9ab411d98ba854dc2af7faa36072f9) | `serd: fix cross-compilation by disabling adding cross flags`                                 |
| [`97256b89`](https://github.com/NixOS/nixpkgs/commit/97256b895353e9b2047cccd331db1fc2eb2fb315) | `inconsolata: revert to working unstable version`                                             |
| [`7dc28c88`](https://github.com/NixOS/nixpkgs/commit/7dc28c88bc4d9cb5ad06f4d7d8b33a5eb0cae079) | `opencv: fix OpenCL linkage`                                                                  |