### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a323570a264da96a0b0bcc1c9aa017794acdc752",
-        "sha256": "0xfrnc3gr2zlzg8m17j1k8c32zhakaa31djb1n9wmc4pg3zq4dg1",
+        "rev": "5b3ac7b07e2479df5c40320b1b218918800919ea",
+        "sha256": "055c8x8g80999iq4knfqv5lwb6939mj1j3s6vl5j6kgjl1h05nbc",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a323570a264da96a0b0bcc1c9aa017794acdc752.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5b3ac7b07e2479df5c40320b1b218918800919ea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`e2ae6cc0`](https://github.com/NixOS/nixpkgs/commit/e2ae6cc0f430307d3ea7511aff44328fdc98e4f3) | `kicad: use new domain name`                                           |
| [`faae63c0`](https://github.com/NixOS/nixpkgs/commit/faae63c0763f73514c1a07cfd5ed613ae1d6371b) | `fluxcd: 0.17.2 -> 0.18.3 (#142082)`                                   |
| [`ff541789`](https://github.com/NixOS/nixpkgs/commit/ff541789ad51d1a2abaeb4dd5d33c0f39ba4f9e9) | `python38Packages.google-cloud-org-policy: 1.1.0 -> 1.2.0`             |
| [`b75ee01a`](https://github.com/NixOS/nixpkgs/commit/b75ee01a92a6a7093e5f45efaba62e12f11b2e8a) | `python38Packages.google-cloud-translate: 3.5.0 -> 3.6.0`              |
| [`6cddd6c6`](https://github.com/NixOS/nixpkgs/commit/6cddd6c6bf87e0849751e4e10c9579c95128b5e1) | `btop: 1.0.16 -> 1.0.18`                                               |
| [`f4acefe3`](https://github.com/NixOS/nixpkgs/commit/f4acefe3aac187468dabeadf34838136478e8208) | `python38Packages.google-cloud-kms: 2.9.0 -> 2.10.0`                   |
| [`820b99a7`](https://github.com/NixOS/nixpkgs/commit/820b99a77d8ea33313a88852384b840e1fadf0df) | `chromium: 94.0.4606.81 -> 95.0.4638.54`                               |
| [`6c156651`](https://github.com/NixOS/nixpkgs/commit/6c156651f450f1fdd57c36796df0af14e201020f) | `android-studio: add fabianhjr to maintainers`                         |
| [`3c1be7cb`](https://github.com/NixOS/nixpkgs/commit/3c1be7cbe8cad9c87ce2316dbd5d79f4a3e2026f) | `themechanger: 0.10.1 -> 0.10.2`                                       |
| [`75b11274`](https://github.com/NixOS/nixpkgs/commit/75b1127499fe89d01466a8e01567f2fe2d9adc3f) | `pure-prompt: 1.17.3 -> 1.18.0`                                        |
| [`c631d6c5`](https://github.com/NixOS/nixpkgs/commit/c631d6c55e9bc32d2ecc3892477bb3e4f85fdaab) | `enlightenment.terminology: use https in url`                          |
| [`a3f93473`](https://github.com/NixOS/nixpkgs/commit/a3f93473e5c2f008b2df54801b48d20383be7a20) | `pavucontrol: 4.0 -> 5.0, format`                                      |
| [`c3b28c1d`](https://github.com/NixOS/nixpkgs/commit/c3b28c1d401b607cfe5865b1ece0b9639b67d2b2) | `uwufetch: styling fixup`                                              |
| [`a2cd9adf`](https://github.com/NixOS/nixpkgs/commit/a2cd9adfe700929e3acabf7d417411eba8293bd5) | `Update pkgs/tools/misc/uwufetch/default.nix`                          |
| [`39b8cfeb`](https://github.com/NixOS/nixpkgs/commit/39b8cfebeda193356926767ff3522f03b12b6908) | `git-branchless: 0.3.2 -> 0.3.6`                                       |
| [`847324fd`](https://github.com/NixOS/nixpkgs/commit/847324fdb51180d307361d8f06be764b9f3f7476) | `oh-my-zsh: 2021-10-13 -> 2021-10-18`                                  |
| [`467bb0f9`](https://github.com/NixOS/nixpkgs/commit/467bb0f93ff3e3be2b8229e003f2ddf127b3b161) | `uwufetch: init at 1.7`                                                |
| [`f9c4594a`](https://github.com/NixOS/nixpkgs/commit/f9c4594aa351cd693254df327348717b1c5e7101) | `procs: 0.11.9 -> 0.11.10`                                             |
| [`25ad00d8`](https://github.com/NixOS/nixpkgs/commit/25ad00d83d5027ee406848b9be829df94c593e73) | `upwork: 5.6.8.0 -> 5.6.9.3`                                           |
| [`ac4e2701`](https://github.com/NixOS/nixpkgs/commit/ac4e27010646b6fec1366e185bf8957280c5f4d2) | `bats: 1.3.0 -> 1.4.1`                                                 |
| [`536f7a87`](https://github.com/NixOS/nixpkgs/commit/536f7a87111ad7528aa1f6e9ad48acb3d329b91e) | `zsh-autocomplete: init at 21.09.22`                                   |
| [`30be6c22`](https://github.com/NixOS/nixpkgs/commit/30be6c22c53ef68c72ed745ba68dc6f87bfcd589) | `nim: 1.4.8 -> 1.6.0`                                                  |
| [`04e1d248`](https://github.com/NixOS/nixpkgs/commit/04e1d2483b15a79937e50cafcc92e2278887c3a7) | `deno: 1.15.1 -> 1.15.2`                                               |
| [`49f64302`](https://github.com/NixOS/nixpkgs/commit/49f6430240f727e7e48ec802122f09751adb29ff) | `msmtp: 1.8.16 -> 1.8.17`                                              |
| [`3cfbadec`](https://github.com/NixOS/nixpkgs/commit/3cfbadec99c6da8c64767a31055361f95ac3ebe5) | `nim: patch compiler to emit native file/line info format`             |
| [`5e415b91`](https://github.com/NixOS/nixpkgs/commit/5e415b911b22e038c6277346d1ead5739af72f80) | `python3Packages.plaid-python: 8.1.0 -> 8.3.0`                         |
| [`a1810f03`](https://github.com/NixOS/nixpkgs/commit/a1810f03d14d89ea4b006a76140943cca1f80a93) | `python3Packages.nulltype: init at 2.3.1`                              |
| [`08489c40`](https://github.com/NixOS/nixpkgs/commit/08489c40ab39af1bb55d4b5cdc3fec2be67981c1) | `fastp: 0.22.0 -> 0.23.1`                                              |
| [`c25a1b7a`](https://github.com/NixOS/nixpkgs/commit/c25a1b7a5afbad87338bc2b800636ae40c0f5f42) | `isa-l: init 2.30.0`                                                   |
| [`faff7f78`](https://github.com/NixOS/nixpkgs/commit/faff7f789b56d79638da0640801d05ad13e44dc8) | `hacpack: fix static build && enable parallel building`                |
| [`4ba2d385`](https://github.com/NixOS/nixpkgs/commit/4ba2d3853506736af43b5bdd6dfe1b1fa16235c0) | `python3Packages.flux-led: 0.24.8 -> 0.24.9`                           |
| [`06c825a9`](https://github.com/NixOS/nixpkgs/commit/06c825a9c23e62870b2d2f89fe571f4341ca514c) | `python3Packages.pyspark: update postPatch and add pythonImportsCheck` |
| [`1f635614`](https://github.com/NixOS/nixpkgs/commit/1f635614e829b9be3d462866f3065e7c484755de) | `wrangler: 1.19.3 -> 1.19.4`                                           |
| [`c1a440b6`](https://github.com/NixOS/nixpkgs/commit/c1a440b6cc781696ac23373f2b71e895cfc2c517) | `doc: rust: target escape hatch has been removed`                      |
| [`b131ad3c`](https://github.com/NixOS/nixpkgs/commit/b131ad3c3e107e1b09ddcf7a056f10afc602c6f4) | `python38Packages.pyspark: 3.1.2 -> 3.2.0`                             |
| [`6ffaaa41`](https://github.com/NixOS/nixpkgs/commit/6ffaaa41ba0796d1a98ed6da0408ff311aa4ce80) | `peep: 0.1.4 -> 0.1.4-post.2021-08-17, remove patch`                   |
| [`53e7de91`](https://github.com/NixOS/nixpkgs/commit/53e7de919ddcd15fbdbe5c8ccf6dd78127f6c1c4) | `lutris: 0.5.8.4 -> 0.5.9.1`                                           |
| [`a443ee36`](https://github.com/NixOS/nixpkgs/commit/a443ee36132180297f98339c55f74cf61b263429) | `ms-dotnettools.csharp: 1.23.2 -> 1.23.15`                             |
| [`e0595113`](https://github.com/NixOS/nixpkgs/commit/e059511348392e9be3ff6db448b2960d71aab405) | `vscode-extensions: refac personal maintainer tools`                   |
| [`338e629f`](https://github.com/NixOS/nixpkgs/commit/338e629f0c230df830c879ea491f84e894a87fd0) | `chromiumBeta: 95.0.4638.49 -> 95.0.4638.54`                           |
| [`ef5f73a8`](https://github.com/NixOS/nixpkgs/commit/ef5f73a844b5f5786f1a13cd67750211336f4fc4) | `python3Packages.millheater: 0.6.2 -> 0.7.3`                           |
| [`8cc87866`](https://github.com/NixOS/nixpkgs/commit/8cc87866b2ccd5e6fa0329d1813e57fa5a842d3c) | `python3Packages.fjaraskupan: 1.0.1 -> 1.0.2`                          |
| [`d3725b30`](https://github.com/NixOS/nixpkgs/commit/d3725b3047d98801d46652c2bf19422457c10cdc) | `kopia: 0.9.2 -> 0.9.3`                                                |
| [`882e5241`](https://github.com/NixOS/nixpkgs/commit/882e52419f0b07ca9fc060cdd78b9798865a9d49) | `android-studio: 2020.3.1.24 → 2020.3.1.25`                            |
| [`cb7459c2`](https://github.com/NixOS/nixpkgs/commit/cb7459c286489c4811d376bbeb3cc59e9a1c0175) | `nixos/hedgedoc: add more options for oauth2`                          |
| [`2bb795ba`](https://github.com/NixOS/nixpkgs/commit/2bb795bab24f00d60b164ab40b504201a0cefa20) | `gnomeExtensions.dash-to-dock: unstable-2021-10-03 -> 70`              |
| [`507d0ead`](https://github.com/NixOS/nixpkgs/commit/507d0eadcbb0d522074d1a2d0427108319952fb6) | `openttd-jgrpp: 0.41.0 -> 0.43.1`                                      |
| [`5fcd6019`](https://github.com/NixOS/nixpkgs/commit/5fcd6019dfa4e99ebce541f3974468e355beb66e) | `openttd: 1.11.2 -> 12.0`                                              |
| [`8e6bf068`](https://github.com/NixOS/nixpkgs/commit/8e6bf0688e269d0e924f57c9426a472dec5f73e3) | `epick: init at 0.5.1`                                                 |
| [`9cb9b011`](https://github.com/NixOS/nixpkgs/commit/9cb9b011ac5843e7b8479dd477112b0c51d250e2) | `gnomeExtensions: auto-update`                                         |
| [`de65b31b`](https://github.com/NixOS/nixpkgs/commit/de65b31b174d16f9085b22407dd80abbc83efcc2) | `discourse.plugins.discourse-openid-connect: init at unstable`         |
| [`46309037`](https://github.com/NixOS/nixpkgs/commit/463090378b7db5b0cbdf44fb10c27edfe8b0e586) | `discourse: add up-plugin.sh`                                          |
| [`5324a863`](https://github.com/NixOS/nixpkgs/commit/5324a863260b5e70f191239ec92f2c598ec52210) | `bitlbee-plugins: use runCommandLocal instead of mkDerivation`         |