### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79f5a81cb3855d7d2e8fe642c78d43da0d6fd9b8",
-        "sha256": "1v7zqwnjm2jsis0qvzsyd33w506z3xbsij4azjay595ig9xjpyfr",
+        "rev": "3ef1d2a9602c18f8742e1fb63d5ae9867092e3d6",
+        "sha256": "0yicccl89rfa5nk4ic46ydihvzsw1phzsypnlzmzrdnwsxi3r9d4",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/79f5a81cb3855d7d2e8fe642c78d43da0d6fd9b8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3ef1d2a9602c18f8742e1fb63d5ae9867092e3d6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`4f9ca7c5`](https://github.com/NixOS/nixpkgs/commit/4f9ca7c56556432c33adb77da765022ae1d4589c) | `Common lisp update (#142209)`                                    |
| [`5b455776`](https://github.com/NixOS/nixpkgs/commit/5b455776e301b85e1180f71b9237b37e00f7134f) | `helmfile: 0.140.1 -> 0.141.0`                                    |
| [`0d20bfd7`](https://github.com/NixOS/nixpkgs/commit/0d20bfd7429cbf10196a954f0278c995be3bf6dc) | `tonelib-gfx: 4.6.6 -> 4.7.0 (#142259)`                           |
| [`995f554e`](https://github.com/NixOS/nixpkgs/commit/995f554ec9795cb2eea3a354389b90a082a427b6) | `python38Packages.PyChromecast: 9.3.0 -> 9.3.1`                   |
| [`6c91deb3`](https://github.com/NixOS/nixpkgs/commit/6c91deb32a1920415d214183b6a58e3c2b2b36f3) | `oh-my-zsh: 2021-10-18 -> 2021-10-19`                             |
| [`214721f8`](https://github.com/NixOS/nixpkgs/commit/214721f8c50d3368fcc67086e121775c47ad16db) | `vscodium: 1.61.1 -> 1.61.2`                                      |
| [`1326545a`](https://github.com/NixOS/nixpkgs/commit/1326545a4e848c532ce8f199aeeb661d051f2f70) | `ocamlPackages.menhirLib: 20210419 -> 20211012`                   |
| [`f1ad6af3`](https://github.com/NixOS/nixpkgs/commit/f1ad6af36aafad0b06de65941dc6bba991bc5d4e) | `vgrep: 2.5.1 -> 2.5.3`                                           |
| [`d6f6c26e`](https://github.com/NixOS/nixpkgs/commit/d6f6c26e397218f82bd87d0a07ab347a315294e4) | `python39Packages.islpy: remove unused input`                     |
| [`1c9842fa`](https://github.com/NixOS/nixpkgs/commit/1c9842fa819c6b0ecf7508aa7bf9e46b45d72488) | `ipe: add desktop file (#141879)`                                 |
| [`531f2bfd`](https://github.com/NixOS/nixpkgs/commit/531f2bfd7dc7fef72fc9a908463a9c2d5ed9ad1d) | `git-cola: 3.10.1 -> 3.11.0`                                      |
| [`d510a8b8`](https://github.com/NixOS/nixpkgs/commit/d510a8b880e930bd8944e3a99880de582596c2e6) | `cht-sh: unstable-2021-04-25 -> unstable-2021-10-20`              |
| [`2d1057f1`](https://github.com/NixOS/nixpkgs/commit/2d1057f19eafc7632afbe00ec5b42797e62fc311) | `gitlab: use fetchYarnDeps`                                       |
| [`149fb9c5`](https://github.com/NixOS/nixpkgs/commit/149fb9c5297743eab8ada70aed66b2a5546efc32) | `hedgedoc: use fetchYarnDeps, add update script`                  |
| [`fcec99fe`](https://github.com/NixOS/nixpkgs/commit/fcec99feec8690b99d5ae2aace8fcaa1052e3bde) | `element-desktop.seshat: use fetchYarnDeps`                       |
| [`9c360923`](https://github.com/NixOS/nixpkgs/commit/9c3609238906c7db8dbaac7ccf389b7234d29fed) | `element-desktop.keytar: use fetchYarnDeps`                       |
| [`0f59dba3`](https://github.com/NixOS/nixpkgs/commit/0f59dba39f98933e67bd4e7c28a422ab027b2176) | `element-desktop: use fetchYarnDeps, add update script`           |
| [`84e02be5`](https://github.com/NixOS/nixpkgs/commit/84e02be598d10f59a8320ee60a3d2efc31339ce2) | `fetchYarnDeps, mkYarnModules: verify the FOD hash is up-to-date` |
| [`cf6f7726`](https://github.com/NixOS/nixpkgs/commit/cf6f772676b4f3cc7bcd04eb75dadcea85c2cb01) | `mkYarnModules: allow passing custom offlineCache`                |
| [`d6e0195c`](https://github.com/NixOS/nixpkgs/commit/d6e0195ccd478ab6c7f46cf93b08804ad3ec6592) | `prefetch-yarn-deps, fetchYarnDeps: init`                         |
| [`7141eb9c`](https://github.com/NixOS/nixpkgs/commit/7141eb9c5790417da38ce5ea5b273cd1aa994307) | `sway: make xwayland optional`                                    |
| [`ab63bfb3`](https://github.com/NixOS/nixpkgs/commit/ab63bfb36b39856109d9c4ba1cc148105e1e2bf2) | `wlroots: make xwayland optional`                                 |
| [`43d9e1c4`](https://github.com/NixOS/nixpkgs/commit/43d9e1c4d12b096a561b7540f6bc6e2260cb8a56) | `python38Packages.plaid-python: 8.3.0 -> 8.4.0`                   |
| [`57af3912`](https://github.com/NixOS/nixpkgs/commit/57af39129bb5a65946344349a66da03a7fbe2c11) | `pdftoipe: init at 7.2.24.1`                                      |
| [`7a34492e`](https://github.com/NixOS/nixpkgs/commit/7a34492ea451b8133262d134cc87f79402d11fef) | `rtorrent: enable paralell building`                              |
| [`9e510d0a`](https://github.com/NixOS/nixpkgs/commit/9e510d0ab1eee6a3bd8483b3d291414fa97a8d0b) | `libtorrent: enable paralell building`                            |
| [`689cfaac`](https://github.com/NixOS/nixpkgs/commit/689cfaac7c4251ddfacbdc7ac7ea155310a55cb0) | `slack: add pipewire support`                                     |
| [`b5560cfc`](https://github.com/NixOS/nixpkgs/commit/b5560cfc5ec29f2921080ab8f62a5eda18480a03) | `graalvm-ce: check if version is latest on update.sh`             |
| [`8abb6e72`](https://github.com/NixOS/nixpkgs/commit/8abb6e72c91ef08847dca4f1f35d0e76d1b7c338) | `graalvm-ce: 21.2.0 -> 21.3.0`                                    |
| [`3527b88d`](https://github.com/NixOS/nixpkgs/commit/3527b88d6071463f6b87e9b6e6caf032c5974e9c) | `aws-sdk-cpp: propagate aws-crt-cpp`                              |
| [`abc03536`](https://github.com/NixOS/nixpkgs/commit/abc03536cad94a67ee3a18f9f925ea6db2cf8fe3) | `python3Packages.faraday-agent-parameters-types: 1.0.1 -> 1.0.2`  |
| [`1caf81fb`](https://github.com/NixOS/nixpkgs/commit/1caf81fb572355778d290570c2cbb396b88614f2) | `python3Packages.faraday-plugins: 1.5.3 -> 1.5.4`                 |
| [`50c22d35`](https://github.com/NixOS/nixpkgs/commit/50c22d35e876ea6b367966ede70fe0c13fe56a46) | `python3Packages.ismartgate: 4.0.1 -> 4.0.3`                      |
| [`a94e0e44`](https://github.com/NixOS/nixpkgs/commit/a94e0e4485560db48c1961dc6a37102ddbb2a8ff) | `drill: specify license`                                          |
| [`a85cb38b`](https://github.com/NixOS/nixpkgs/commit/a85cb38ba5689e0d828df7d347fcc4c5bea143c8) | `sawjap: init at 1.5.10`                                          |
| [`347fb5b4`](https://github.com/NixOS/nixpkgs/commit/347fb5b441d435c487c9179edbdc7bd9e1296c31) | `ocamlPackages.sawja: 1.5.8 → 1.5.10`                             |
| [`7ede5251`](https://github.com/NixOS/nixpkgs/commit/7ede52510dcdc9f9da20398abf8d7cfd99d989ab) | `python3Packages.flux-led: 0.24.9 -> 0.24.12`                     |
| [`e7094205`](https://github.com/NixOS/nixpkgs/commit/e7094205ecadf12545a3a0e38ae28652d6d7fc75) | `python38Packages.teslajsonpy: 1.1.2 -> 1.2.0`                    |
| [`276ace1e`](https://github.com/NixOS/nixpkgs/commit/276ace1e6dfe9c1ae163445a2144021d5deec8f7) | `python38Packages.spacy-transformers: 1.1.0 -> 1.1.1`             |
| [`0898fcbc`](https://github.com/NixOS/nixpkgs/commit/0898fcbc3dc30bdf2dc4eec9b5adda544e1987bd) | `python38Packages.somecomfort: 0.7.0 -> 0.8.0`                    |
| [`a656c647`](https://github.com/NixOS/nixpkgs/commit/a656c6471fce9d10a83955c84df67e6f6f85d3db) | `python38Packages.smpplib: 2.1.0 -> 2.2.0`                        |
| [`349eacdc`](https://github.com/NixOS/nixpkgs/commit/349eacdc736c852464f8255917490e1a4051cdf7) | `python38Packages.python-crontab: 2.5.1 -> 2.6.0`                 |
| [`330e6a9b`](https://github.com/NixOS/nixpkgs/commit/330e6a9b469db15e7551d7824d2e3929720f0a9b) | `ncspot: 0.8.2 -> 0.9.0`                                          |
| [`1d99959c`](https://github.com/NixOS/nixpkgs/commit/1d99959c36e91078d0aa7f3a5f6fd23dd9aa1229) | `difftastic: 0.10.1 -> 0.11.0`                                    |
| [`b7428350`](https://github.com/NixOS/nixpkgs/commit/b7428350b95e97f82de9b01df60855f7d2022738) | `vscode: 1.61.1 -> 1.61.2`                                        |
| [`638d1655`](https://github.com/NixOS/nixpkgs/commit/638d1655b79767d9f0bb472b74e242822d9e638f) | `uefitool.new-engine: A58 -> A59`                                 |
| [`ca7af0e2`](https://github.com/NixOS/nixpkgs/commit/ca7af0e2fa4fe06f0915da7348c2346471d7f541) | `python38Packages.mypy-boto3-s3: 1.18.64 -> 1.18.65`              |
| [`0fe0a838`](https://github.com/NixOS/nixpkgs/commit/0fe0a8383513a41bb9bd3d14da44e4f167ea01bd) | `routinator: remove patch`                                        |
| [`85a18cf3`](https://github.com/NixOS/nixpkgs/commit/85a18cf3fec8da4d1411c4d70bc45ed70d99b667) | `nmon: fix cross-compiling`                                       |
| [`d32824e7`](https://github.com/NixOS/nixpkgs/commit/d32824e71da8268aba24343d33c4320cf642a793) | `radare2: 5.4.0 -> 5.4.2`                                         |
| [`cd5ff4fe`](https://github.com/NixOS/nixpkgs/commit/cd5ff4fe245a7c1dfb574c6022185bcdcd909912) | `matrix-synapse: 1.44.0 -> 1.45.0`                                |
| [`86c33bba`](https://github.com/NixOS/nixpkgs/commit/86c33bba0d2d4d438d6b6c8175212b8f2526ad29) | `python3Packages.pywizlight: 0.4.7 -> 0.4.8`                      |
| [`bbbd18fb`](https://github.com/NixOS/nixpkgs/commit/bbbd18fbdf8efd24d9cb276a353acd83d6abf96b) | `python3Packages.pycares: 4.0.0 -> 4.1.2`                         |
| [`5b9d44bd`](https://github.com/NixOS/nixpkgs/commit/5b9d44bdf247220f2a5801dba23ec614dc94514e) | `python3Packages.pyspnego: 0.2.0 -> 0.3.0`                        |
| [`dbb48820`](https://github.com/NixOS/nixpkgs/commit/dbb4882075bb3a5f9d05ca51affa65b642004c4b) | `python3Packages.twilio: 7.1.0 -> 7.2.0`                          |
| [`0f89fd60`](https://github.com/NixOS/nixpkgs/commit/0f89fd6076f9c062d20d2dd727ee110be99d7a52) | `python3Packages.stevedore: 3.4.0 -> 3.5.0`                       |
| [`ecebb0d7`](https://github.com/NixOS/nixpkgs/commit/ecebb0d75fd2e74b498a1fcf2e55054c3c57b847) | `pythonPackages.pydal: init at 20210626.3`                        |
| [`145736a0`](https://github.com/NixOS/nixpkgs/commit/145736a0d772110c24da9ed6a0001cbfef0d3755) | `termscp: init at 0.7.0`                                          |
| [`eed2b296`](https://github.com/NixOS/nixpkgs/commit/eed2b2960bf1f7a2a7a5cd11cfab01f655176b56) | `hiksink: init at 1.2.0`                                          |
| [`698a14b9`](https://github.com/NixOS/nixpkgs/commit/698a14b975278c8ab1b8058e8d0279f1972661ee) | `vapoursynth-editor: R19 -> R19-mod-4`                            |
| [`5f3551af`](https://github.com/NixOS/nixpkgs/commit/5f3551afd921db1825a540b2fd61f4b249e5f282) | `vapoursynth: R55 -> R57`                                         |
| [`dc2bdfbb`](https://github.com/NixOS/nixpkgs/commit/dc2bdfbb3bc68791544e4ec935aac6044b270b62) | `vapoursynth: remove flags for optional plugins`                  |
| [`d99a24ed`](https://github.com/NixOS/nixpkgs/commit/d99a24ed01c8869feec5e134855fa2fcecdfc20d) | `maintainers: add yrd`                                            |