### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f0c03a48df21a1b8a19ade6fe67c9ace5a2bb65f",
-        "sha256": "1nydbxnzl9j2i9laa91mx5dib90lg2605aww86rm9zg62qgv5d3d",
+        "rev": "38d21595b8fb0a744aa31c5794013bf42cf98fa9",
+        "sha256": "1syg7y7440lw9hzfxra8fyp1rc2vbxsfqrpa04knwjj1mc9xbr0z",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f0c03a48df21a1b8a19ade6fe67c9ace5a2bb65f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/38d21595b8fb0a744aa31c5794013bf42cf98fa9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                            |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`38d21595`](https://github.com/NixOS/nixpkgs/commit/38d21595b8fb0a744aa31c5794013bf42cf98fa9) | `ocamlPackages.ocaml_text: remove at 0.8`                 |
| [`a7c65469`](https://github.com/NixOS/nixpkgs/commit/a7c6546991f67eeaa09c739c636bafe4010a56e3) | `nixos/peertube:add release notes`                        |
| [`cba4aeee`](https://github.com/NixOS/nixpkgs/commit/cba4aeee5d4d2ea0b4218605640afb9684dd98b9) | `nixos/tests: add peertube test`                          |
| [`4c092350`](https://github.com/NixOS/nixpkgs/commit/4c092350ed0375f24d64918f77b5c14bc250ee33) | `nixos/peertube: init service`                            |
| [`5729103d`](https://github.com/NixOS/nixpkgs/commit/5729103df3e35b5139deac00cec9739da5d57ba5) | `peertube: init at 3.4.1`                                 |
| [`050ec589`](https://github.com/NixOS/nixpkgs/commit/050ec589879272d055acd25462f3b8d6aa8f7d54) | `maintainers: Add Steven Roose`                           |
| [`f0a0389d`](https://github.com/NixOS/nixpkgs/commit/f0a0389dfca84a72c43259dee87691ec6eb464b5) | `vector: 0.16.1 -> 0.17.3`                                |
| [`db3764a2`](https://github.com/NixOS/nixpkgs/commit/db3764a245880ecaa163e16d104fbfccb7f352b2) | `oniguruma: 6.9.6 -> 6.9.7.1`                             |
| [`6f20d8ef`](https://github.com/NixOS/nixpkgs/commit/6f20d8efd43175febf210fe8148d14dcbfc99eee) | `meilisearch: 0.21.1 -> 0.23.1`                           |
| [`118fc125`](https://github.com/NixOS/nixpkgs/commit/118fc1254aad28b349e4739ae489b299d654ee70) | `python3Packages.uproot: 4.1.1 -> 4.1.5`                  |
| [`3c3998ee`](https://github.com/NixOS/nixpkgs/commit/3c3998ee91f35705241f1f4df892a62a3bf92af5) | `pythonPackages.powerlineMemSegment: kebab-case`          |
| [`86d572c8`](https://github.com/NixOS/nixpkgs/commit/86d572c86a58b96b70b0f82c49278d6339c7500c) | `mpd: 0.22.11 -> 0.23.2, activate pipewire`               |
| [`6c7a6bf8`](https://github.com/NixOS/nixpkgs/commit/6c7a6bf895f86eb2ef263a42b0ef99ff6482098c) | `jami: init 20211005.2.251ac7d`                           |
| [`0c2f2c74`](https://github.com/NixOS/nixpkgs/commit/0c2f2c746fdeb0e6168d42cab335231e2d21d0e6) | `intel-gmmlib: 21.3.1 -> 21.3.2`                          |
| [`ef9b6b9c`](https://github.com/NixOS/nixpkgs/commit/ef9b6b9cd0c63313651b3f905b8abe26967b5006) | `ring-daemon: remove`                                     |
| [`b475247b`](https://github.com/NixOS/nixpkgs/commit/b475247b852aa3cb010443546d9ffd7bef3f46c6) | `ocamlPackages.lambdasoup: 0.7.2 → 0.7.3`                 |
| [`d08875a4`](https://github.com/NixOS/nixpkgs/commit/d08875a433b47f8d1360568054f7c751ce88c9b7) | `soupault: 3.1.0 -> 3.2.0`                                |
| [`872080e3`](https://github.com/NixOS/nixpkgs/commit/872080e31c44d8581d96e6260276203b44456e14) | `kotlin-native: init at 1.5.31`                           |
| [`d212adce`](https://github.com/NixOS/nixpkgs/commit/d212adce2ab3d0e631f6e48288d3d0d6c9e7286b) | `storrent: init at 2021-10-10`                            |
| [`2aaefb47`](https://github.com/NixOS/nixpkgs/commit/2aaefb4701ea0ebe1fbaaeadfdc33333ad1245ae) | `kodi.packages.steam-library: 0.8.0 -> 0.8.1`             |
| [`67c1c4f1`](https://github.com/NixOS/nixpkgs/commit/67c1c4f11032cdc9baa44882248143c85b27a0f7) | `gitkraken: 8.0.1 -> 8.1.0`                               |
| [`ced47fa5`](https://github.com/NixOS/nixpkgs/commit/ced47fa5824c0967d7c3cff5577e1cc6f9343d67) | `vscode-extensions.hashicorp.terraform: 2.15.0 -> 2.16.0` |
| [`f9b4e32c`](https://github.com/NixOS/nixpkgs/commit/f9b4e32ca88b72a0f0fdd5fd7a491b7853ad845f) | `dosbox-staging:  writeShellScript into makeWrapper`      |
| [`076ce972`](https://github.com/NixOS/nixpkgs/commit/076ce97202d8544c33e9545cea6503e21cb063c1) | `dosbox-staging: discard redundant option`                |
| [`28efdf72`](https://github.com/NixOS/nixpkgs/commit/28efdf72da7128aa8503ed99311a128f41041e14) | `dosbox-staging: rename alsaLib to alsa-lib`              |
| [`d9a3ddd2`](https://github.com/NixOS/nixpkgs/commit/d9a3ddd2f6b0df72f80def7af95e04e70b9a8ad1) | `dosbox-staging: rename pkgconfig to pkg-config`          |
| [`16c2826c`](https://github.com/NixOS/nixpkgs/commit/16c2826c1ad157520f6d110ed33970844021a695) | `dosbox-staging: init @ 0.77.1`                           |
| [`f21a491d`](https://github.com/NixOS/nixpkgs/commit/f21a491d3fe8970283c8a59062accb637583c9e1) | `racket: patch the runtime variant detection`             |