### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "38d21595b8fb0a744aa31c5794013bf42cf98fa9",
-        "sha256": "1syg7y7440lw9hzfxra8fyp1rc2vbxsfqrpa04knwjj1mc9xbr0z",
+        "rev": "360d65e180403b940afcc93d68d5329488af14eb",
+        "sha256": "00ag86iwnczig8a1vcls7g33kqcicgs9dad3hhjmqaqbzlh0bfrj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/38d21595b8fb0a744aa31c5794013bf42cf98fa9.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/360d65e180403b940afcc93d68d5329488af14eb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| [`2e4300bf`](https://github.com/NixOS/nixpkgs/commit/2e4300bf8b7df72e95803de6fa1aea9537c3c9c7) | `element-desktop: 1.9.2 -> 1.9.3 (#142871)`                                                                            |
| [`042b6258`](https://github.com/NixOS/nixpkgs/commit/042b62583e08b05ed8e7ee0b3530ae16b495286b) | `hqplayerd: fix gupnp version mismatches with fc34`                                                                    |
| [`25bb6455`](https://github.com/NixOS/nixpkgs/commit/25bb6455682f75b3b22c4bb2e7d9659fb7d60c7a) | `hqplayerd: 4.26.0-67 -> 4.26.2-69`                                                                                    |
| [`1a83d487`](https://github.com/NixOS/nixpkgs/commit/1a83d487b75ddd4d154b5f5a11df6a3c15f3444f) | `graphql-client: init at 0.10.0`                                                                                       |
| [`7d22ae19`](https://github.com/NixOS/nixpkgs/commit/7d22ae1937364a483d2dd405cb1795c5c8c3ceea) | `nixos/release-notes: fix 21.11 release name`                                                                          |
| [`aa224e0f`](https://github.com/NixOS/nixpkgs/commit/aa224e0f414ad86718c88f36283e4884ea93c111) | `himalaya: 0.4.0 -> 0.5.1`                                                                                             |
| [`587ea4f6`](https://github.com/NixOS/nixpkgs/commit/587ea4f6e5dbc393cf8c0887f54735e7ff724bf7) | `python3Packages.pypoint: 2.2.0 -> 2.2.1`                                                                              |
| [`052e144f`](https://github.com/NixOS/nixpkgs/commit/052e144f75b6587b2d81536237ddc0690604e764) | `python3Packages.youless-api: 0.14 -> 0.15`                                                                            |
| [`11b14160`](https://github.com/NixOS/nixpkgs/commit/11b141609b071e140486842a1c42b7b876449b2b) | `python3Packages.rokuecp: 0.8.2 -> 0.8.4`                                                                              |
| [`da56cea2`](https://github.com/NixOS/nixpkgs/commit/da56cea292285b2e0d1a187b1b5a54b637ab151a) | `python3Packages.pykodi: 0.2.6 -> 0.2.7`                                                                               |
| [`d7b40b20`](https://github.com/NixOS/nixpkgs/commit/d7b40b207d1fe149ea04addb0d85aca197529256) | `python3Packages.aiounittest: 1.4.0 -> 1.4.1`                                                                          |
| [`be8a53f7`](https://github.com/NixOS/nixpkgs/commit/be8a53f7aebf97ad4050eb4b9938d415d641ac3a) | `python3Packages.pyatv: 0.8.2 -> 0.9.5 (#142821)`                                                                      |
| [`7cbb26bb`](https://github.com/NixOS/nixpkgs/commit/7cbb26bb9d9b5f21834b334f9b6681f0056ee4b2) | `librespot: 0.3.0 -> 0.3.1 (#142855)`                                                                                  |
| [`faba7563`](https://github.com/NixOS/nixpkgs/commit/faba756358bb24a023789d35f01728a3bff89c83) | `vimPlugins.marks-nvim: init at 2021-10-23`                                                                            |
| [`f55446b5`](https://github.com/NixOS/nixpkgs/commit/f55446b5e386baa94238c665a1cab6fac0ddc183) | `vimPlugins.cmp-under-comparator: init at 2021-10-22`                                                                  |
| [`126dfe79`](https://github.com/NixOS/nixpkgs/commit/126dfe79c00f80f1a658192e6eea3cbffe9afd6e) | `vimPlugins.cmp-pandoc-references: init at 2021-10-11`                                                                 |
| [`260af912`](https://github.com/NixOS/nixpkgs/commit/260af9121e453c22b862ba57dbb13830711e22dc) | `vimPlugins.cmp-omni: init at 2021-09-28`                                                                              |
| [`f94c4b7f`](https://github.com/NixOS/nixpkgs/commit/f94c4b7f61f18ccd130455d4663e66d53bf93e8a) | `vimPlugins: update`                                                                                                   |
| [`e9370bd8`](https://github.com/NixOS/nixpkgs/commit/e9370bd8185ca22665b714a3c705ef2faf00157c) | `vimPlugins.vim-lean: fix branch`                                                                                      |
| [`ea9be2b7`](https://github.com/NixOS/nixpkgs/commit/ea9be2b781ddeaeeeb7a7aa1571cd88795af09de) | `deno: 1.15.2 -> 1.15.3`                                                                                               |
| [`ce6a14f9`](https://github.com/NixOS/nixpkgs/commit/ce6a14f9d02d326582a637855e5a79ee774e35b0) | `rust-petname: 1.1.1 -> 1.1.2`                                                                                         |
| [`37a5c59b`](https://github.com/NixOS/nixpkgs/commit/37a5c59bdfcbfbe6abfa9b94aae6b39d502b2b5d) | `metasploit: 6.1.10 -> 6.1.11`                                                                                         |
| [`fb390df2`](https://github.com/NixOS/nixpkgs/commit/fb390df254c5473aab39c7bba50104450557ec4a) | `ocaml-minisat: 0.3 -> 0.4`                                                                                            |
| [`1ecc9846`](https://github.com/NixOS/nixpkgs/commit/1ecc9846a705771825c704c57949f74cb8ac90a8) | `metasploit: update update.sh`                                                                                         |
| [`40cc369f`](https://github.com/NixOS/nixpkgs/commit/40cc369f756018a05b8c251825f2d7294b59ec8e) | `black: add autophagy as maintainer`                                                                                   |
| [`b4d6ef1c`](https://github.com/NixOS/nixpkgs/commit/b4d6ef1c9423686d9a8eebbf63bab47897f2f1de) | `maintainers: add autophagy`                                                                                           |
| [`fb4c3dec`](https://github.com/NixOS/nixpkgs/commit/fb4c3dec25deb30e57d5bb6b0bd3a3ed62d2c0a2) | `linux-manual: init at 5.14.14`                                                                                        |
| [`8ecfaf35`](https://github.com/NixOS/nixpkgs/commit/8ecfaf3543413c49f1e938032c7a30ac80ebd05d) | `dockerTools: Fix test`                                                                                                |
| [`44403b72`](https://github.com/NixOS/nixpkgs/commit/44403b728b3869685fa8bceaa9e491f5b5ad5347) | `patchutils: add 0.4.2 variant + remove meta.executable + enable tests + fix inter-dependencies by wrapping (#141567)` |
| [`4dde9c38`](https://github.com/NixOS/nixpkgs/commit/4dde9c38a4588d7609a2cfb1f6980fb34ee4b455) | `libbpf: 0.4.0 -> 0.5.0`                                                                                               |
| [`f6b9ffdd`](https://github.com/NixOS/nixpkgs/commit/f6b9ffdd8aa9bd5306e9de0b9b4373ad2cfb5caf) | `protoc-gen-grpc-web: 1.2.1 -> 1.3.0`                                                                                  |
| [`5d025ae9`](https://github.com/NixOS/nixpkgs/commit/5d025ae9aba771e14ff92ec0d2e039ffc4915c40) | `Revert "kibana update nodejs 10 -> 14"`                                                                               |
| [`a56b5d81`](https://github.com/NixOS/nixpkgs/commit/a56b5d81eddb7eb710b04554a0a461fc9bb2cb2a) | `step-cli: add mainProgram`                                                                                            |
| [`46b9f725`](https://github.com/NixOS/nixpkgs/commit/46b9f72566a437a76dcfaef43689dae25aeb8a4c) | `step-cli: 0.17.6 -> 0.17.7`                                                                                           |
| [`11f6dd14`](https://github.com/NixOS/nixpkgs/commit/11f6dd14201acd575b7c470aeb26fea9b38efdfd) | `steampipe: 0.8.5 -> 0.9.0`                                                                                            |
| [`e674a463`](https://github.com/NixOS/nixpkgs/commit/e674a4637730906d080924819870ea76d9e96896) | `python3Packages.aiomusiccast: 0.11.0 -> 0.12.0`                                                                       |
| [`6688c522`](https://github.com/NixOS/nixpkgs/commit/6688c522542b25cc4a1ee106eddb18dc3d7a4133) | `nixos/hadoop: add better test`                                                                                        |
| [`91bb2b70`](https://github.com/NixOS/nixpkgs/commit/91bb2b7016de43dfc08fde834d135954369737dc) | `nixos/hadoop: fix yarn, add more service configuration options`                                                       |
| [`ee1fd49e`](https://github.com/NixOS/nixpkgs/commit/ee1fd49ebe2f48ce73a4904a986ebf73b4ade3b7) | `hadoop: 2->3`                                                                                                         |
| [`0dfb1669`](https://github.com/NixOS/nixpkgs/commit/0dfb1669763fe8e182954f35ea2d55b9374662e1) | `sqlfluff: 0.7.0 -> 0.7.1`                                                                                             |
| [`09011397`](https://github.com/NixOS/nixpkgs/commit/090113970fd695a5715fb168d4b124516b501d50) | `sysz: 1.3.0 -> 1.4.3`                                                                                                 |
| [`47228e36`](https://github.com/NixOS/nixpkgs/commit/47228e369e38b26745acfd0962aa54f221e78379) | `python3Packages.herepy: 3.5.4 -> 3.5.5`                                                                               |
| [`a5e3a7e1`](https://github.com/NixOS/nixpkgs/commit/a5e3a7e16c274d7bc2624758dffcf12d817b13be) | `btcpayserver: use buildDotnetModule`                                                                                  |
| [`e8b4515f`](https://github.com/NixOS/nixpkgs/commit/e8b4515f39d8393c77baf5d751db5e764c3d0fc7) | `nbxplorer: use buildDotnetModule`                                                                                     |
| [`26cf7887`](https://github.com/NixOS/nixpkgs/commit/26cf7887b5e4b9f3285f49fb6588f1c52b436ebd) | `buildDotnetModule: fix variable handling`                                                                             |
| [`df68c121`](https://github.com/NixOS/nixpkgs/commit/df68c1213fe928f2539f00fe530d4937e66d125d) | `yoda: 1.9.0 -> 1.9.1`                                                                                                 |
| [`a1f00bc0`](https://github.com/NixOS/nixpkgs/commit/a1f00bc029a0eff2e2655dfbc96c5d29528aa2e9) | `lhapdf: 6.3.0 -> 6.4.0`                                                                                               |
| [`0a0795ee`](https://github.com/NixOS/nixpkgs/commit/0a0795ee9ed9b7ffa856d9bb153e5a4c73e6e561) | `svtplay-dl: 4.5 -> 4.7`                                                                                               |
| [`76a77c0b`](https://github.com/NixOS/nixpkgs/commit/76a77c0bfb0424ef67702c81fdc87bf76e2c99b3) | `plasma5: fix evaluation with aliases disabled and thunderbolt enabled`                                                |
| [`75a5d557`](https://github.com/NixOS/nixpkgs/commit/75a5d5575c65abe079ed9f5aff1a33e7e9d079f1) | `zettlr: 2.0.0 -> 2.0.1`                                                                                               |
| [`437bf811`](https://github.com/NixOS/nixpkgs/commit/437bf811a5ee900c5fdc92d60097ad1dc3991436) | `python3Packages.aiolookin: init at 0.0.3`                                                                             |
| [`10bed7ee`](https://github.com/NixOS/nixpkgs/commit/10bed7eeee68c4a50ae00ac61a44687af52d0a26) | `sqlitebrowser: enable support for encrypted databases`                                                                |
| [`3b46f18b`](https://github.com/NixOS/nixpkgs/commit/3b46f18b027c595e79c7986218bb47d565f927f7) | `zbackup: fix`                                                                                                         |
| [`33787315`](https://github.com/NixOS/nixpkgs/commit/3378731579284e37be9586988b017f380cb9d49e) | `yabridge: Fix for wine 6.20`                                                                                          |
| [`a244dd98`](https://github.com/NixOS/nixpkgs/commit/a244dd9886ffacba526ad0272d236b8bb28db9b4) | `yabridgectl: 3.5.2 -> 3.6.0`                                                                                          |
| [`2f6153f1`](https://github.com/NixOS/nixpkgs/commit/2f6153f1f78de56dfa4b874c0e2ec5777fbe04b0) | `yabridge: 3.5.2 -> 3.6.0`                                                                                             |
| [`587af88e`](https://github.com/NixOS/nixpkgs/commit/587af88ec2456c116f47dc17dc2fbe588d0e0f36) | `python3Packages.zeroconf: 0.36.8 -> 0.36.9`                                                                           |
| [`b42d95b9`](https://github.com/NixOS/nixpkgs/commit/b42d95b95b92b39c218089c8a7e0b0d798380e17) | `checkov: 2.0.505 -> 2.0.509`                                                                                          |
| [`1d0318e8`](https://github.com/NixOS/nixpkgs/commit/1d0318e8b9e70f3997307d10d870f5901435d9a5) | `scryer-prolog: update dependency lexical-core to fix build`                                                           |
| [`941500de`](https://github.com/NixOS/nixpkgs/commit/941500de8f6bcd8cc3543a522b521140cfe85990) | `thunderbird: 91.2.0 -> 91.2.1`                                                                                        |
| [`0084c41a`](https://github.com/NixOS/nixpkgs/commit/0084c41abfbf5fa6e19539d7a32f3bce4c3eb6b7) | `nixos/systemd: add remote-cryptsetup.target`                                                                          |
| [`f488a525`](https://github.com/NixOS/nixpkgs/commit/f488a5250e5ea3d1774b7803bf77ea0b39071aa1) | `thunderbird-bin: 91.1.2 -> 91.2.1`                                                                                    |
| [`98e3e2fe`](https://github.com/NixOS/nixpkgs/commit/98e3e2fe9e7bae56c37b8a287c04fe967418ec64) | `vde2: explicitly disable parallel building`                                                                           |
| [`73846b37`](https://github.com/NixOS/nixpkgs/commit/73846b372fe93b5c674ff56e59b2a1dfa70d3d85) | `nixos/acme: add webroots to ReadWritePaths`                                                                           |