### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7c01d3c63c2f2a5bc97e412c73d9949b73cb80c",
-        "sha256": "1plnpncdanlhwshkwq85qa783b0479hii6vimxhsnja0gmdyrnvq",
+        "rev": "113fcf34abdccf21811d3cb3eca793408de7e531",
+        "sha256": "1rfmvymz34q6bhscpzfwk6fmrkdvp0wxpk4x80n4fdhn0fxmcqjr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c7c01d3c63c2f2a5bc97e412c73d9949b73cb80c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/113fcf34abdccf21811d3cb3eca793408de7e531.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`75d64a33`](https://github.com/NixOS/nixpkgs/commit/75d64a336b34567021c88e641ff791649cc07681) | `nixos/restic: rename s3CredentialsFile to environmentFile`         |
| [`cb0031ed`](https://github.com/NixOS/nixpkgs/commit/cb0031ed2a407c111fdf18c2d1a95d833a3bf6be) | `warzone2100: 4.1.3 -> 4.2.0`                                       |
| [`cdb3a561`](https://github.com/NixOS/nixpkgs/commit/cdb3a5613ec451150bef08a6757bae6c81784074) | `uniscribe: init at 1.7.0 (#142990)`                                |
| [`1531006d`](https://github.com/NixOS/nixpkgs/commit/1531006d915c4a75f37af1a94e6f4c325902569b) | `ocamlPackages.mrmime: init 0.5`                                    |
| [`05011436`](https://github.com/NixOS/nixpkgs/commit/050114362fdaf5b4fdb075aa09952bfa028c9970) | `ocamlPackages.unstrctrd: init 0.3`                                 |
| [`153957a3`](https://github.com/NixOS/nixpkgs/commit/153957a38918075dadfd9556a988c9769eb6b46b) | `ocamlPackages.prettym: init 0.0.2`                                 |
| [`c255780e`](https://github.com/NixOS/nixpkgs/commit/c255780e698277a5bf06a622d5dab15ec28314ce) | `ocamlPackages.rosetta: init 0.3.0`                                 |
| [`95068b46`](https://github.com/NixOS/nixpkgs/commit/95068b46474f04defff9a74edeabf2af639dd3ee) | `ocamlPackages.yuscii: init 0.3.0`                                  |
| [`1f621984`](https://github.com/NixOS/nixpkgs/commit/1f621984d42fb58ea067e2d890f209ea659432ad) | `ocamlPackages.uuuu: init 0.2.0`                                    |
| [`b397bd63`](https://github.com/NixOS/nixpkgs/commit/b397bd63b7253be15e0da34557ec1ab847fd3148) | `ocamlPackages.coin: init 0.1.3`                                    |
| [`42efb2d4`](https://github.com/NixOS/nixpkgs/commit/42efb2d484a2845282c3de24a3c9f96eda7a0601) | `mdzk: init at 0.4.2`                                               |
| [`8a667bea`](https://github.com/NixOS/nixpkgs/commit/8a667bea3e2df67a7014d6963b75d10586627646) | `linuxPackages.nvidia_x11: 470.74 -> 495.44`                        |
| [`9392afc5`](https://github.com/NixOS/nixpkgs/commit/9392afc5691677cacc38087c0a3dc0e6a64e00a0) | `vaultenv: reduce closure size`                                     |
| [`7c7cd951`](https://github.com/NixOS/nixpkgs/commit/7c7cd951c543833cb09eb7cc59745bcd9f538b92) | `nixos/step-ca: fix comment typo`                                   |
| [`cb5860ff`](https://github.com/NixOS/nixpkgs/commit/cb5860ff98fd4b4712d88a3ef5328ca93df6c013) | `zbar: disable dbus by default because the implementation is buggy` |
| [`4441cfb0`](https://github.com/NixOS/nixpkgs/commit/4441cfb0e37637cc1954730401b0e166e587ef42) | `libint: 2.6.0 -> 2.7.1 (#142835)`                                  |
| [`da91093f`](https://github.com/NixOS/nixpkgs/commit/da91093fb94b79a3553bd85cbbd7ce3d1633bd92) | `tree-sitter: update grammars`                                      |
| [`f4100c90`](https://github.com/NixOS/nixpkgs/commit/f4100c907902debe4d009392248314032c2e6737) | `protontricks: 1.6.0 → 1.6.1`                                       |
| [`d2be84ae`](https://github.com/NixOS/nixpkgs/commit/d2be84ae19c2076d19e3875c11572840ee1b91b6) | `python3Packages.velbus-aio: 2021.10.6 -> 2021.10.7`                |
| [`2193fe74`](https://github.com/NixOS/nixpkgs/commit/2193fe747d8221a97f07673a77bd4f00b2ca4dcc) | `python3Packages.pygls: fix darwin build`                           |
| [`66ea992d`](https://github.com/NixOS/nixpkgs/commit/66ea992d482e456b95d31704501f9eb7477981bc) | `fritzing: 0.9.6 -> unstable-2021-09-22 (#136142)`                  |
| [`e937fd52`](https://github.com/NixOS/nixpkgs/commit/e937fd52690d7b0f534ebd7867f24e9c1c453234) | `libotf: format`                                                    |
| [`22ff13ad`](https://github.com/NixOS/nixpkgs/commit/22ff13ada23d1e24f5929b958882d411634f2185) | `binance: init at 1.25.0`                                           |
| [`0027a124`](https://github.com/NixOS/nixpkgs/commit/0027a1246ae2802a290e545d45b65a5d3a230324) | `python3Packages.pylgnetcast: 0.3.4 -> 0.3.5`                       |
| [`ddc02d8c`](https://github.com/NixOS/nixpkgs/commit/ddc02d8c258d2ce75e5ccfd27c96e32b7fd1fdc2) | `teraform-providers.kubernetes: 2.6.0 -> 2.6.1`                     |
| [`a8b37b3c`](https://github.com/NixOS/nixpkgs/commit/a8b37b3c8123b50901e377e1fa89489bfc6e9145) | `terraform-providers.kubernetes: 2.5.0 -> 2.6.0`                    |
| [`d8ccdf66`](https://github.com/NixOS/nixpkgs/commit/d8ccdf66df8c90234eafdd8a1354599f805c9687) | `ventoy-bin: 1.0.51 -> 1.0.56 (#141616)`                            |
| [`e3fe0cad`](https://github.com/NixOS/nixpkgs/commit/e3fe0cad989ca41d852681f9221414e6022b813c) | `python3Packages.zigpy: 0.38.0 -> 0.39.0`                           |
| [`0a03a7b4`](https://github.com/NixOS/nixpkgs/commit/0a03a7b48b31fabb66475d06dd958593f0398f37) | `kubescape: 1.0.126 -> 1.0.127`                                     |
| [`03023512`](https://github.com/NixOS/nixpkgs/commit/03023512770f49b45fe871f94c9f9cb7212911f7) | `thiefmd: init at 0.2.4`                                            |
| [`baf76e1a`](https://github.com/NixOS/nixpkgs/commit/baf76e1aa2606a3a05757afd801814eddd74c907) | `python3Packages.pytest-sanic: 1.8.1 -> 1.9.1`                      |
| [`a354a240`](https://github.com/NixOS/nixpkgs/commit/a354a240de8250ed3c46c7c6a87874c73e60e0ae) | `m17n-lib: fix cross-compilation`                                   |
| [`c5ef7d70`](https://github.com/NixOS/nixpkgs/commit/c5ef7d7091930cf0818401d6752ea10aa732c759) | `m17n-db: fix cross-compilation`                                    |
| [`be3d12d4`](https://github.com/NixOS/nixpkgs/commit/be3d12d4e528a082693b90bd7e8e57e52b4de13e) | `libotf: fix cross-compilation by applying a patch from debian`     |
| [`86ef6baf`](https://github.com/NixOS/nixpkgs/commit/86ef6baf5d5f6869f163bc39d261c9c82fb164ed) | `python3Packages.pytm: init at 1.2.0 (#142609)`                     |
| [`0b080b9e`](https://github.com/NixOS/nixpkgs/commit/0b080b9e9344cd448c9a27d2a7e6b43785271010) | `cargo-diet: 1.2.2 -> 1.2.3`                                        |
| [`a9aa3c2a`](https://github.com/NixOS/nixpkgs/commit/a9aa3c2a5fe5d97404e3c33555bf155b7259efea) | `topgrade: 7.1.0 -> 8.0.0`                                          |
| [`2a5a4c89`](https://github.com/NixOS/nixpkgs/commit/2a5a4c89db6855239bb90a63fa8db7cfa7be976f) | `ycmd: remove ? null, little cleanup, formatting`                   |
| [`cd1b1ad0`](https://github.com/NixOS/nixpkgs/commit/cd1b1ad03b51cebf3ee36c28818642b8cc55bceb) | `linuxPackages.rr-zen_workaround: set meta.broken`                  |
| [`f00dbf88`](https://github.com/NixOS/nixpkgs/commit/f00dbf88e1e8b462e49dd148f4b1054379bb1ed2) | `conftest: 0.28.1 -> 0.28.2`                                        |
| [`b24be6dc`](https://github.com/NixOS/nixpkgs/commit/b24be6dcff7fc2d11329ecb3629b551f084bcf1a) | `Revert "vte: 0.64.2 → 0.66.0"`                                     |
| [`0ebf090e`](https://github.com/NixOS/nixpkgs/commit/0ebf090e30ab71cc066c6a6ab1ba2e5dd866185f) | `checksec: 2.4.0 -> 2.5.0`                                          |
| [`537ce9bd`](https://github.com/NixOS/nixpkgs/commit/537ce9bd4531cf18e983b48cf38686a393175977) | `make sure gpgv is found`                                           |
| [`9acca2cc`](https://github.com/NixOS/nixpkgs/commit/9acca2cc2da5cf24850a2c45cef525af23e0d4ab) | `python3Packages.pytradfri: 7.1.0 -> 7.1.1`                         |
| [`497090f6`](https://github.com/NixOS/nixpkgs/commit/497090f6d070f87c10e320a0bca68c50d5f5ab41) | `python3Packages.pyvicare: 2.13.0 -> 2.13.1`                        |
| [`44caa4ac`](https://github.com/NixOS/nixpkgs/commit/44caa4acf23be94b0880fda413716cba912bfae6) | `home-assistant: update component-packages`                         |
| [`f4b91c6c`](https://github.com/NixOS/nixpkgs/commit/f4b91c6cbd706af390f2113e847b0830ae5a3efa) | `python3Packages.pylgnetcast: init at 0.3.4`                        |
| [`3914ffc6`](https://github.com/NixOS/nixpkgs/commit/3914ffc6d17b4e26a940d206f2c99cfcd26e6a6c) | `backblaze-b2: 3.0.1 -> 3.0.3`                                      |
| [`d769983d`](https://github.com/NixOS/nixpkgs/commit/d769983d5a353fcaa5d485f26a5aa1afd23ae6f7) | `python3Packages.b2sdk: 1.12.0 -> 1.13.0`                           |
| [`1b783a6f`](https://github.com/NixOS/nixpkgs/commit/1b783a6f04f7c8f7f0ce5fa3344a8167379a7ee0) | `python3Packages.logfury: 0.1.2 -> 1.0.1`                           |
| [`99cfa6cf`](https://github.com/NixOS/nixpkgs/commit/99cfa6cff8efa75f78ba64e520f5beed65494e6c) | `dunst: 1.6.1 -> 1.7.0`                                             |
| [`5e01edf2`](https://github.com/NixOS/nixpkgs/commit/5e01edf2d27ff52e21517a32ef2babef2e4b698a) | `alttpr-opentracker: init at 1.8.2`                                 |
| [`c56ac665`](https://github.com/NixOS/nixpkgs/commit/c56ac665925bc13b471aca8216813d077e2fc172) | `python3Packages.simple_di: init at 0.1.2`                          |
| [`0fb60ce1`](https://github.com/NixOS/nixpkgs/commit/0fb60ce16b6155787db8d11dc264c8671ad2a375) | `calibre: fix hash`                                                 |
| [`21fddb64`](https://github.com/NixOS/nixpkgs/commit/21fddb64072aecda8431214e06a3d66f291e0bfe) | `jami: add alias ring-daemon -> jami-daemon`                        |
| [`fe891f53`](https://github.com/NixOS/nixpkgs/commit/fe891f534f247971d2d8aafc54dc471ed345020f) | `depotdownloader: use buildDotnetModule`                            |
| [`ab5c10c4`](https://github.com/NixOS/nixpkgs/commit/ab5c10c42a95de2192f270ea13ba05e149e8cead) | `php80: 8.0.11 -> 8.0.12, fix CVE-2021-21703`                       |
| [`af404d85`](https://github.com/NixOS/nixpkgs/commit/af404d852f39b18257024d8010192d74829c0917) | `php74: 7.4.24 -> 7.4.25, fix CVE-2021-21703`                       |
| [`177f87b0`](https://github.com/NixOS/nixpkgs/commit/177f87b09616419523e319c3c16178ff5f7736d0) | `elpa-generated fixup duplication`                                  |
| [`b66c9ca0`](https://github.com/NixOS/nixpkgs/commit/b66c9ca00840960f1428c931149c8bfd56488faf) | `elpa packages 2021-10-25`                                          |
| [`b17581b3`](https://github.com/NixOS/nixpkgs/commit/b17581b3debce66c436f6080cf83eb7264990923) | `nongnu packages 2021-10-25`                                        |
| [`9fd4bd02`](https://github.com/NixOS/nixpkgs/commit/9fd4bd027cd0234c545a9e9f2d5302c706ca3e47) | `melpa packages 2021-10-25`                                         |
| [`05b60061`](https://github.com/NixOS/nixpkgs/commit/05b60061ace07a110cfa0451415331b3372bf888) | `elements: 0.18.1.12 -> 0.21.0`                                     |
| [`412d5729`](https://github.com/NixOS/nixpkgs/commit/412d5729429c8413dc26f9eea2dd2e8e21002ba1) | `python3Packages.hg-git: init at 0.10.2`                            |
| [`9dfc47b0`](https://github.com/NixOS/nixpkgs/commit/9dfc47b0a16c6b3a510399aa128182decacc4751) | `source-han-serif: 1.001R -> 2.000R`                                |
| [`8705d082`](https://github.com/NixOS/nixpkgs/commit/8705d0826fdc6675941a4d56b2a7935f13167348) | `imagemagick6: 6.9.12-19 -> 6.9.12-26`                              |
| [`e7808caf`](https://github.com/NixOS/nixpkgs/commit/e7808cafea59d1ff5b3f62c0bfc498165a7aa1bc) | `imagemagick: 7.1.0-9 -> 7.1.0-11`                                  |
| [`517850fc`](https://github.com/NixOS/nixpkgs/commit/517850fced3b5de6693d5b49ad14e5a12d968741) | `pythonPackages.insegel: init at 1.3.1`                             |
| [`c81675bc`](https://github.com/NixOS/nixpkgs/commit/c81675bcacd22c9e058e479bd9fb6c53ec59d480) | `gb-backup: 2021-04-07 -> 2021-08-16`                               |
| [`bedcb97d`](https://github.com/NixOS/nixpkgs/commit/bedcb97d246bf99939c150240a06de2c40426b11) | `ryujinx: 1.0.7065 -> 1.0.7086`                                     |
| [`49d19b79`](https://github.com/NixOS/nixpkgs/commit/49d19b7945c2c519d3bc7611237ff7f656f681a6) | `snakemake: 6.7.0 -> 6.10.0`                                        |
| [`85a6e037`](https://github.com/NixOS/nixpkgs/commit/85a6e037e797697ef000497b16f1a2772fed3309) | `pythia: 8.305 -> 8.306`                                            |
| [`1c9b4552`](https://github.com/NixOS/nixpkgs/commit/1c9b4552622658b41509b5efdc253028716d535c) | `android-tools: 31.0.2 -> 31.0.3`                                   |
| [`551ce87f`](https://github.com/NixOS/nixpkgs/commit/551ce87fa11b2eeb9bd878ee4a42db353f328400) | `python3Packages.debugpy: 1.5.0 -> 1.5.1`                           |
| [`ca8b3fcb`](https://github.com/NixOS/nixpkgs/commit/ca8b3fcbe4fc388de7451afe16198dec2c0257e1) | `exploitdb: 2021-10-20 -> 2021-10-23`                               |
| [`7b7f3dfb`](https://github.com/NixOS/nixpkgs/commit/7b7f3dfbe4dbecb3b6a72e29efe898106f385c78) | `nixos/seafile: init service`                                       |
| [`22ecb14d`](https://github.com/NixOS/nixpkgs/commit/22ecb14d70e3ce81673005a1d04214d8ac2b3037) | `seahub: init at 8.0.7`                                             |
| [`32e6d672`](https://github.com/NixOS/nixpkgs/commit/32e6d672bc70e61d00b5a6dcd4d2447715270903) | `seafile-server: init at 8.0.7`                                     |
| [`3860ea7b`](https://github.com/NixOS/nixpkgs/commit/3860ea7bb0735b2a250c68da685bd4bc9d00fe39) | `seafile-shared: build CLI client`                                  |
| [`67979f2f`](https://github.com/NixOS/nixpkgs/commit/67979f2ff0737783465013a5e06f142a3a6b5b68) | `seafile-shared: prefer commit hash over tag`                       |
| [`abe6b7ee`](https://github.com/NixOS/nixpkgs/commit/abe6b7ee708c02aeb168ca20a3d3fa2ef29a21c1) | `oniguruma: enable posix API`                                       |
| [`793a6d84`](https://github.com/NixOS/nixpkgs/commit/793a6d84ef90f21b2c57be11bff1c8acdfc71556) | `pysearpc: init at 3.2.0`                                           |
| [`87eaa626`](https://github.com/NixOS/nixpkgs/commit/87eaa6260ea8477e274ab24b4160dab85251125e) | `django-formtools: init at 2.2`                                     |
| [`48934ca5`](https://github.com/NixOS/nixpkgs/commit/48934ca5c14c4c5726eb4534afa99e0943898116) | `django-statici18n: init at 2.0.1`                                  |
| [`dae098f4`](https://github.com/NixOS/nixpkgs/commit/dae098f472998f3b1ef80569acbdfa24a54ba71e) | `vscode-extensions.chenglou92.rescript-vscode: init at 1.1.3`       |
| [`bbe3bbbd`](https://github.com/NixOS/nixpkgs/commit/bbe3bbbd9e0ae1a9c6ab8828b302b792c70ac2f2) | `maintainers: add dlip`                                             |