### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "113fcf34abdccf21811d3cb3eca793408de7e531",
-        "sha256": "1rfmvymz34q6bhscpzfwk6fmrkdvp0wxpk4x80n4fdhn0fxmcqjr",
+        "rev": "77382d5ebf92ac0ae021d02c73357f5e11d9e3ad",
+        "sha256": "12phd3as4w5p9963bg2agxh99zhrykh3iy638yjf5dzfawsvmgf3",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/113fcf34abdccf21811d3cb3eca793408de7e531.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/77382d5ebf92ac0ae021d02c73357f5e11d9e3ad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`77382d5e`](https://github.com/NixOS/nixpkgs/commit/77382d5ebf92ac0ae021d02c73357f5e11d9e3ad) | `cbqn: 0.pre+unstable=2021-10-09 -> 0.pre+date=2021-10-20`             |
| [`f6d0781d`](https://github.com/NixOS/nixpkgs/commit/f6d0781d3ec460886304c4754921feee3ada93c0) | `mbqn: 0.pre+unstable=2021-10-06 -> 0.pre+date=2021-10-21`             |
| [`3ed95b14`](https://github.com/NixOS/nixpkgs/commit/3ed95b14e289fdc6ffc13f94cf61e50500cb2140) | `notcurses: 2.4.2 -> 2.4.8 (#143031)`                                  |
| [`ce91173e`](https://github.com/NixOS/nixpkgs/commit/ce91173e840f8d27c5032e02f5144239dab206a5) | `python38Packages.janus: 0.6.1 -> 0.6.2`                               |
| [`72adca0a`](https://github.com/NixOS/nixpkgs/commit/72adca0ae5305a5f12891db5d00b77af0b746d39) | `python38Packages.google-cloud-speech: 2.10.0 -> 2.11.0`               |
| [`9a3abb23`](https://github.com/NixOS/nixpkgs/commit/9a3abb23cff6eafe020dc79b4b3f767862f96b9b) | `a52dec: fix src url`                                                  |
| [`aafee157`](https://github.com/NixOS/nixpkgs/commit/aafee15790d17a5516f178a3723c00e8872a7ab9) | `kubescape: 1.0.127 -> 1.0.128`                                        |
| [`3b225fa3`](https://github.com/NixOS/nixpkgs/commit/3b225fa342e6bccbb21060cdd186eab5f68e99ee) | `opencv: 4.5.2 -> 4.5.4`                                               |
| [`a25d54aa`](https://github.com/NixOS/nixpkgs/commit/a25d54aae360fea4ee25565554c9a938a6327431) | `wesnoth: 1.14.17 -> 1.16.0`                                           |
| [`f17c3516`](https://github.com/NixOS/nixpkgs/commit/f17c3516fb298dc11890a358d25d0b652e7ac300) | `makeRustPlatform: allow to easily override stdenv`                    |
| [`3096e73c`](https://github.com/NixOS/nixpkgs/commit/3096e73c9e3d4bc2009451edef10ea2cd43f7fea) | `autosuspend: 4.0.0 -> 4.0.1`                                          |
| [`22a500a3`](https://github.com/NixOS/nixpkgs/commit/22a500a3f87bbce73bd8d777ef920b43a636f018) | `pam_mount: do not re-prompt for password`                             |
| [`97e39fca`](https://github.com/NixOS/nixpkgs/commit/97e39fcafa593264f4aba8338b69a9293f772e15) | `nixosTests.hibernate: Make sure machines are shut down when finished` |
| [`0335855b`](https://github.com/NixOS/nixpkgs/commit/0335855bc62d1b8007fd0d700373f153fbbec092) | `kustomize: 4.3.0 -> 4.4.0`                                            |
| [`90cb25ce`](https://github.com/NixOS/nixpkgs/commit/90cb25cea17d8e22da4665410a06ab6e6e811f8a) | `python3Packages.python-nmap: 0.6.4 -> 0.7.1`                          |
| [`230b912f`](https://github.com/NixOS/nixpkgs/commit/230b912f26862049c358bc7259dc60f81da57958) | `python3Packages.dotmap: 1.3.24 -> 1.3.25`                             |
| [`766c2f14`](https://github.com/NixOS/nixpkgs/commit/766c2f14feb3e8baa59a935d6b17ecbcc35a4b70) | `python3Packages.angrop: 9.0.10281 -> 9.0.10339`                       |
| [`6d1744d0`](https://github.com/NixOS/nixpkgs/commit/6d1744d0f584e21cabafca6bac4d8025ad8c72d9) | `python3Packages.angr: 9.0.10281 -> 9.0.10339`                         |
| [`d6db4892`](https://github.com/NixOS/nixpkgs/commit/d6db4892f140ae32253e115e07452556238e1d01) | `python3Packages.cle: 9.0.10281 -> 9.0.10339`                          |
| [`ec444364`](https://github.com/NixOS/nixpkgs/commit/ec44436429d5aedbc43f02febe25d0de9dceb05a) | `python3Packages.claripy: 9.0.10281 -> 9.0.10339`                      |
| [`38b3ee1d`](https://github.com/NixOS/nixpkgs/commit/38b3ee1d00dace3e072f2ce4ce4781be6aafcf4b) | `python3Packages.pyvex: 9.0.10281 -> 9.0.10339`                        |
| [`b3ed7e1f`](https://github.com/NixOS/nixpkgs/commit/b3ed7e1f690be0d8276947f05129634be34274ac) | `python3Packages.ailment: 9.0.10281 -> 9.0.10339`                      |
| [`b8e5c1e2`](https://github.com/NixOS/nixpkgs/commit/b8e5c1e2c696e48f207ae6a10176907d32abe4c3) | `python3Packages.archinfo: 9.0.10281 -> 9.0.10339`                     |
| [`ccd348ae`](https://github.com/NixOS/nixpkgs/commit/ccd348aeb8a7e5197d092d73ce820eaedd2821b4) | `rdma-core: 37.0 -> 37.1`                                              |
| [`c63692d8`](https://github.com/NixOS/nixpkgs/commit/c63692d89abf6090c6603812276c2158499c104f) | `sqlcipher: compile with zlib, readline and tcl support by default`    |
| [`ab3b7624`](https://github.com/NixOS/nixpkgs/commit/ab3b7624605a9da5c974626df5bcac5609707930) | `maven: 3.8.2 -> 3.8.3`                                                |
| [`e038cc7f`](https://github.com/NixOS/nixpkgs/commit/e038cc7ff1778211d7c6ca247ac142b4f389233b) | `gnss-sdr: mention update issue`                                       |
| [`f081767d`](https://github.com/NixOS/nixpkgs/commit/f081767d97b6b10b762209bd5c984afa53504172) | `stig: 0.11.2a0 -> 0.12.2a0; clarify license`                          |
| [`b6ef9916`](https://github.com/NixOS/nixpkgs/commit/b6ef9916e411bd4c19cec842656c8a80a0a69b5b) | `sherpa: 2.2.10 -> 2.2.11`                                             |
| [`58025e85`](https://github.com/NixOS/nixpkgs/commit/58025e85871f2509cb21fe06c326657f81227e84) | `gnuradio: Reenable thrift support`                                    |
| [`6e552641`](https://github.com/NixOS/nixpkgs/commit/6e552641b70c5209ce2cad2ceda0ee787c811b65) | `gnuradio: Add missing runtime python packages`                        |
| [`a7851a7a`](https://github.com/NixOS/nixpkgs/commit/a7851a7a96558a9ec9c46642c78b884da045dd77) | `gnuradio: Fix 2 upstream issues`                                      |
| [`d60a4a44`](https://github.com/NixOS/nixpkgs/commit/d60a4a44924a1def6040cd9c71ca6807e15c31f7) | `gnuradio: Remove fetchSubmodules argument`                            |
| [`e950fb48`](https://github.com/NixOS/nixpkgs/commit/e950fb484ba914b098a432a5e2e83885ff2bdb23) | `thrift: 0.14.2 -> 0.15.0`                                             |
| [`d6fa3fef`](https://github.com/NixOS/nixpkgs/commit/d6fa3fef68b1081c65ebb642b4dfa56d1c1162db) | `gnuradio: Make hasFeature function simpler`                           |
| [`18eb4531`](https://github.com/NixOS/nixpkgs/commit/18eb4531cd291303e6ade31f07a4e72a8cadcc82) | `gnuradio-wrapped: Assume that wrapping is done with python-support`   |
| [`63b4f69e`](https://github.com/NixOS/nixpkgs/commit/63b4f69e40a7476c6e9a4bd09968ff5ee9afd897) | `gnuradio: 3.9.2.0 -> 3.9.3.0`                                         |
| [`b6be203e`](https://github.com/NixOS/nixpkgs/commit/b6be203ec43703d5aae499b255971bcfc14de9bd) | `gnuradio3_8: 3.8.3.1 -> 3.8.4.0`                                      |
| [`1582136b`](https://github.com/NixOS/nixpkgs/commit/1582136bf22f91b065b518811b0cd4447cde13b7) | `home-assistant: update component-packages`                            |