### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f3494b3436bbedf8bb9cfe157871e8c1d398225",
-        "sha256": "1yi59ijmk065p49agammdyl34cjkc9a35hhg5ssi49d679rann1m",
+        "rev": "3d29e432018ea74bb54eea4b6d475f74dfb00568",
+        "sha256": "1b292wzrz0radr752gizixz3zgddwd1jf1420p5cv9bcxk5jxzbn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/7f3494b3436bbedf8bb9cfe157871e8c1d398225.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3d29e432018ea74bb54eea4b6d475f74dfb00568.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`3d29e432`](https://github.com/NixOS/nixpkgs/commit/3d29e432018ea74bb54eea4b6d475f74dfb00568) | `exodus: 20.8.19 -> 21.10.25 (#143047)`                                              |
| [`50341b0c`](https://github.com/NixOS/nixpkgs/commit/50341b0cd8c5acba28ad63c9d1ff29ec3d66c173) | `build(deps): bump zeebe-io/backport-action from 0.0.5 to 0.0.6 (#140848)`           |
| [`6157e823`](https://github.com/NixOS/nixpkgs/commit/6157e823db047235e8752a5ffb4bb52d761c8d57) | `shotgun: 2.2.0 -> 2.2.1`                                                            |
| [`842a0d94`](https://github.com/NixOS/nixpkgs/commit/842a0d94cbb0a385854e15d4f6fde57714981abd) | `fetchYarnDeps: use fakeSha256 if no hash is given`                                  |
| [`1565ab97`](https://github.com/NixOS/nixpkgs/commit/1565ab9717d8be76765c1995720ecb160b1541e3) | `prefetch-yarn-deps: ignore file: dependencies`                                      |
| [`6c99b3d0`](https://github.com/NixOS/nixpkgs/commit/6c99b3d0b746e132fe6173e6dadc89fcc16f4d36) | `prefetch-yarn-deps: support git:// dependencies`                                    |
| [`d9ff013d`](https://github.com/NixOS/nixpkgs/commit/d9ff013d0ca7ca1a1dc9c181319bb6c5a78dd376) | `alacritty: include patch to fix PTY EIO error`                                      |
| [`8a7f053f`](https://github.com/NixOS/nixpkgs/commit/8a7f053f3c35a9da701fdf2d066e5d67a5c6c289) | `pantheon.switchboard-plug-about: fix wallpaper path`                                |
| [`d49d9a24`](https://github.com/NixOS/nixpkgs/commit/d49d9a24b7b5b0ddfe349c355e79aa992c108a74) | `nixos/pantheon: mention latest appcenter changes in manual`                         |
| [`758d85fe`](https://github.com/NixOS/nixpkgs/commit/758d85fed36cb9b4f9d96e37bf6f3ff012614df1) | `pantheon.elementary-mail: drop downstream patch`                                    |
| [`829e9209`](https://github.com/NixOS/nixpkgs/commit/829e92098e49997f56c484e0d9560419fce416cc) | `pantheon.appcenter: drop downstream patch`                                          |
| [`79259c35`](https://github.com/NixOS/nixpkgs/commit/79259c359937f4931e4db8f3707aa99f10c058ee) | `terraform-providers.teleport: init at 7.3.0 (#138972)`                              |
| [`ffe31dec`](https://github.com/NixOS/nixpkgs/commit/ffe31dec259290c6862cdc67066e103564e718ac) | `s6-man-pages: 2.11.0.0.1 -> 2.11.0.0.2`                                             |
| [`3cd131bf`](https://github.com/NixOS/nixpkgs/commit/3cd131bf3c0212c8d7851d352db365766f3c2b2d) | `execline-man-pages: 2.8.1.0.1 -> 2.8.1.0.2`                                         |
| [`102e4cbc`](https://github.com/NixOS/nixpkgs/commit/102e4cbc157eb8022ff6200c17531bc6eda4c329) | `s6-networking-man-pages: 2.5.0.0.1 -> 2.5.0.0.2`                                    |
| [`249a6c76`](https://github.com/NixOS/nixpkgs/commit/249a6c764d137fccbdb639ecdb76cb043bb75ac0) | `python3Packages.qcs-api-client: 0.8.0 -> 0.14.0`                                    |
| [`a4e9b0d5`](https://github.com/NixOS/nixpkgs/commit/a4e9b0d576f9272ccc067aefaa074a629e6a92a1) | `python38Packages.oslo-context: 3.3.1 -> 3.4.0`                                      |
| [`4dc3596f`](https://github.com/NixOS/nixpkgs/commit/4dc3596fd172c26ed418c1eac64044a28679d21e) | `nixosTests.yq: remove, move to yq package`                                          |
| [`5e447cfa`](https://github.com/NixOS/nixpkgs/commit/5e447cfae55b7083baeb78fd6c941bf0b2d7746f) | `mautrix-whatsapp: 0.1.8 -> 0.1.9`                                                   |
| [`30d581b2`](https://github.com/NixOS/nixpkgs/commit/30d581b29deabf668d793f3ee8b604895c4fcdf8) | `wrapFish: fix early variable expansion`                                             |
| [`d89f2808`](https://github.com/NixOS/nixpkgs/commit/d89f28084c22dc68c723384ccbf7826d50936353) | `ustreamer: 3.27 -> 4.6`                                                             |
| [`a3286ac6`](https://github.com/NixOS/nixpkgs/commit/a3286ac6cb49a84f44f7ba936ea1b3a724f69770) | `gromacs: fix formatting`                                                            |
| [`face360c`](https://github.com/NixOS/nixpkgs/commit/face360c0802e054b200d06bffc1b8681b13b207) | `gromacs: replace lib.lists.optional with lib.optional`                              |
| [`7545018f`](https://github.com/NixOS/nixpkgs/commit/7545018f7ddae97eef2a6502195fb3aac409c38f) | `gajim: 1.3.2 -> 1.3.3`                                                              |
| [`f67a38a1`](https://github.com/NixOS/nixpkgs/commit/f67a38a13af93be8a2d86d3c14e5b05a09a91579) | `nbxmpp: 2.0.3 -> 2.0.4`                                                             |
| [`5fdab076`](https://github.com/NixOS/nixpkgs/commit/5fdab076f060f1d7c3f76def7d2122b9071080fe) | `maintainers: remove eduardosm`                                                      |
| [`927f40c9`](https://github.com/NixOS/nixpkgs/commit/927f40c95226b4b1b80f1c541bda808a3a2959ee) | `python38Packages.pyatv: 0.9.5 -> 0.9.6`                                             |
| [`6b4dfd8d`](https://github.com/NixOS/nixpkgs/commit/6b4dfd8db1b1cf4b3be5932124a45534c511122c) | `factorio-experimental: 1.1.44 -> 1.1.45`                                            |
| [`20c20cd2`](https://github.com/NixOS/nixpkgs/commit/20c20cd204d01cb1400704d014fda4eee9928669) | `tpm2-tools: 5.1.1 -> 5.2`                                                           |
| [`52dd13c6`](https://github.com/NixOS/nixpkgs/commit/52dd13c6335cc51cfa96206b20a43a3fb35a138a) | `kakoune: 2021.08.28 -> 2021.10.28`                                                  |
| [`093181aa`](https://github.com/NixOS/nixpkgs/commit/093181aad09b7b1672e75730f508ed3009150819) | `tutanota-desktop: 3.88.4 -> 3.89.5`                                                 |
| [`e4d824f4`](https://github.com/NixOS/nixpkgs/commit/e4d824f4e3238132162c0a1032770094ae4f59d0) | `gromacs: bool switches for MPI and CUDA`                                            |
| [`963d7583`](https://github.com/NixOS/nixpkgs/commit/963d758334fec50b1000f92cd0abc868e7850da2) | `schildichat-web, schildichat-desktop: init at 1.9.0-sc.1 (#142662)`                 |
| [`dcb22ec2`](https://github.com/NixOS/nixpkgs/commit/dcb22ec2803eb9d94f0f2148840446c61b8a3ba2) | `terraformer: 0.8.17 -> 0.8.18`                                                      |
| [`a3b4d121`](https://github.com/NixOS/nixpkgs/commit/a3b4d12191145d57fcc060f2ab053ae01b35addd) | `teleport: 7.3.0 -> 7.3.2`                                                           |
| [`ab3097a2`](https://github.com/NixOS/nixpkgs/commit/ab3097a23743013bfef79929d2a516e1212193b0) | `postgresqlPackages.timescaledb: 2.4.2 -> 2.5.0`                                     |
| [`73386604`](https://github.com/NixOS/nixpkgs/commit/73386604849ecc83c0bfcd7409fe1cb8699eb767) | `tor: 0.4.6.7 -> 0.4.6.8`                                                            |
| [`f9c890c9`](https://github.com/NixOS/nixpkgs/commit/f9c890c99871d23ff16c2e947a6dcf4e22abe079) | `thinkfan: 1.2.2 -> 1.3.0`                                                           |
| [`19e71dfa`](https://github.com/NixOS/nixpkgs/commit/19e71dfa871977759b6a3eff7479e4a07e77038b) | `gromacs: 2020.4 -> 2021.3, cuda, mpi cleanups, performance tunings`                 |
| [`978b3e19`](https://github.com/NixOS/nixpkgs/commit/978b3e19e4c913120f9452bc42a08b262bfec1a0) | `gitlab: 14.3.3 -> 14.4.0`                                                           |
| [`df4689c7`](https://github.com/NixOS/nixpkgs/commit/df4689c7c23b74fc5624afda3fe4550652b78070) | `python38Packages.textdistance: 4.2.1 -> 4.2.2`                                      |
| [`33b3dae3`](https://github.com/NixOS/nixpkgs/commit/33b3dae3480526f03065310321e813a5f466b078) | `rl-2111: Note the addition of virtualisation.useNixStoreImage...`                   |
| [`46f75211`](https://github.com/NixOS/nixpkgs/commit/46f75211446641a5ddb603fbf89b08f30656ebdf) | `make-disk-image: Add an argument to only build a Nix store image`                   |
| [`ed2497b4`](https://github.com/NixOS/nixpkgs/commit/ed2497b4050946a148c1efa9688d951dce339b77) | `gitlab.tests: Improve test performance`                                             |
| [`2781f84b`](https://github.com/NixOS/nixpkgs/commit/2781f84bce11789a7d8127559a6de0d5cdf92e93) | `discourse.tests: Improve test performance`                                          |
| [`329a4461`](https://github.com/NixOS/nixpkgs/commit/329a4461a7a1898b3aad13968a232a054422c4fb) | `nixos/testing-python: Copy test script derivations to nodes`                        |
| [`aa22fa9c`](https://github.com/NixOS/nixpkgs/commit/aa22fa9c0b6329e7d557be363c13508a8d46487d) | `trivial-builders: Add writeStringReferencesToFile`                                  |
| [`af9f6d9a`](https://github.com/NixOS/nixpkgs/commit/af9f6d9a2aeb279408bcbb90db16ef3f727e2601) | `nixos/qemu-vm: Rename pathsInNixDB to additionalPaths`                              |
| [`84839b39`](https://github.com/NixOS/nixpkgs/commit/84839b395f5740789af7a843aaeea80ac2f6f60b) | `nixos/qemu-vm: Allow building a Nix store image instead of using 9p`                |
| [`87d8eec0`](https://github.com/NixOS/nixpkgs/commit/87d8eec0691caf16b924ad7401a29e2783b12896) | `make-disk-image: Add additionalPaths argument`                                      |
| [`398a73ac`](https://github.com/NixOS/nixpkgs/commit/398a73ac980f2e89981d8d704d7e800bb7a9bfaf) | `make-disk-image: Add copyChannel argument`                                          |
| [`56c5efa2`](https://github.com/NixOS/nixpkgs/commit/56c5efa25b51e4a1b8452ef2adb18d96dadfb323) | `make-disk-image: Reintroduce the installBootLoader argument`                        |
| [`b7c19f70`](https://github.com/NixOS/nixpkgs/commit/b7c19f700d3df0e727382d720810700b7cd8c8b8) | `tz: 0.5 -> 0.6.1`                                                                   |
| [`ea8d53ed`](https://github.com/NixOS/nixpkgs/commit/ea8d53ed168e84f7ea6589323fa8300d8bf385db) | `nixos/pantheon: use Inter as default sans-serif font`                               |
| [`1c649410`](https://github.com/NixOS/nixpkgs/commit/1c64941016edfa2d28a637cb2333cd84ef908007) | `pantheon.elementary-default-settings: fix gtk-theme-name and gtk-font-name`         |
| [`7dd57213`](https://github.com/NixOS/nixpkgs/commit/7dd57213b388b61e3416eb75d2eae5bbc7d3cc22) | `pantheon.gala: use smooth scroll events to handle mouse wheel in multitasking view` |
| [`72fe1b16`](https://github.com/NixOS/nixpkgs/commit/72fe1b16627e439b36777282ef5cad7522b6613f) | `pantheon.elementary-screenshot: 6.0.0 -> 6.0.1`                                     |
| [`d4e5b14e`](https://github.com/NixOS/nixpkgs/commit/d4e5b14e90e1b6b5912807ac32e9b1000228470d) | `pantheon.switchboard-plug-display: 2.3.1 -> 2.3.2`                                  |
| [`bd49bccd`](https://github.com/NixOS/nixpkgs/commit/bd49bccdf7b808a9f4b459cb066709b98d4e1ab1) | `pantheon.elementary-mail: 6.2.0 -> 6.3.0`                                           |
| [`89707c93`](https://github.com/NixOS/nixpkgs/commit/89707c93aa20187153b90dc8868b595e79236a12) | `pcalc: enable on darwin`                                                            |
| [`cb788cef`](https://github.com/NixOS/nixpkgs/commit/cb788cef507014364430a0ef7ead842879c95762) | `gitea: 1.15.5 -> 1.15.6`                                                            |
| [`a0dba13e`](https://github.com/NixOS/nixpkgs/commit/a0dba13edeb10264ba664ea282d91f27f91ed033) | `python39Packages.dogpile-core: normalise name`                                      |
| [`71ed943a`](https://github.com/NixOS/nixpkgs/commit/71ed943a867ba602eec6feabd9ada703993df87c) | `python39Packages.imapclient: normalise name`                                        |
| [`2b218f52`](https://github.com/NixOS/nixpkgs/commit/2b218f52c8edc554c8ad492300e4e6ad2c8b897e) | `python39Packages: normalise aliases and add missing comments`                       |
| [`846ceff3`](https://github.com/NixOS/nixpkgs/commit/846ceff3b324f25e6bb202f6e1ea33194a0d2fbd) | `python39Packages.sqlalchemy-migrate: normalise attr`                                |
| [`db19e681`](https://github.com/NixOS/nixpkgs/commit/db19e681254e043bffa9e9b47bd64493302ca614) | `python39Packages.dogpile-cache: normalise attr, cleanup`                            |
| [`dded550f`](https://github.com/NixOS/nixpkgs/commit/dded550fcd240bdf3b0acc0740ad174975d3b4a0) | `doc: fix typo`                                                                      |
| [`44ef047e`](https://github.com/NixOS/nixpkgs/commit/44ef047ef6a2e139c8dd954fb84c6e95852094f9) | `session-desktop-appimage: 1.7.3 -> 1.7.4`                                           |
| [`7a25b79f`](https://github.com/NixOS/nixpkgs/commit/7a25b79f525e874f8b36d356a3ef77ef7ab77513) | `vnote: 3.7.0 -> 3.8.1`                                                              |
| [`89707a11`](https://github.com/NixOS/nixpkgs/commit/89707a11483b56c813b5303f3471c565c786f347) | `python3Packages.gvm-tools: 21.6.1 -> 21.10.0`                                       |
| [`9d16f56a`](https://github.com/NixOS/nixpkgs/commit/9d16f56a8b177ec1de872d23c3a38adbe6709cf0) | `rbw: 1.3.0 -> 1.4.0`                                                                |
| [`f88653b1`](https://github.com/NixOS/nixpkgs/commit/f88653b1561f9bdde0124067b52542e4d9755d2a) | `rbw: Apply nixpkgs-fmt`                                                             |
| [`9603ad9f`](https://github.com/NixOS/nixpkgs/commit/9603ad9f17cfb2ad99b839fb0c1213993fab47e6) | `factorio-experimental: 1.1.43 -> 1.1.44`                                            |
| [`448c1fcf`](https://github.com/NixOS/nixpkgs/commit/448c1fcf7632386c3b42cc03671621fe7537a541) | `monitor: 0.10.0 -> 0.11.0`                                                          |
| [`ba3b2992`](https://github.com/NixOS/nixpkgs/commit/ba3b2992c98b4a5433d1c7cf7e0c3cc4d43f0cab) | `emacs.pkgs.bqn-mode: 2021-09-27 -> 2021-10-26`                                      |
| [`c5f7188a`](https://github.com/NixOS/nixpkgs/commit/c5f7188ac58b83e49e2b677027c56e449358cba7) | `lua-fmt: init at 2.6.0`                                                             |
| [`75806416`](https://github.com/NixOS/nixpkgs/commit/75806416237c253ccd872f7ef567a39d882dfff7) | `factorio: add support for updating specific release_type/release_channel`           |
| [`c2c0862c`](https://github.com/NixOS/nixpkgs/commit/c2c0862c7abd164d0cd0029a74164fee76f2182a) | `factorio-experimental: 1.1.42 -> 1.1.43`                                            |
| [`f45e4ff3`](https://github.com/NixOS/nixpkgs/commit/f45e4ff331b267b433510446f71c2877afe40b44) | `plasma-workspace: include patch from 5.23.2`                                        |
| [`1e1a06af`](https://github.com/NixOS/nixpkgs/commit/1e1a06afcd545c59c00b2a2a1ac1772a21747b09) | `plasma5: 5.23.0 -> 5.23.1`                                                          |
| [`d40a9e79`](https://github.com/NixOS/nixpkgs/commit/d40a9e79e4241007cb4dbed72e8cbbf23561dada) | `plasma5: 5.22.90 -> 5.23.0`                                                         |
| [`0a6c143c`](https://github.com/NixOS/nixpkgs/commit/0a6c143cd73efef4a45af30b3c902c9751aef3ac) | `kwayland-integration: add missing dependencies`                                     |
| [`2be06151`](https://github.com/NixOS/nixpkgs/commit/2be06151bc731ce67aa7a3be0babf6d8eee8768d) | `plasma-workspace: include fix from 5.23.1`                                          |
| [`5cf1732f`](https://github.com/NixOS/nixpkgs/commit/5cf1732f927bb5225d2fe01bc98da9feeb32ddf5) | `plasma-workspace: update patch`                                                     |
| [`d142f31c`](https://github.com/NixOS/nixpkgs/commit/d142f31c2e51921e0ca4ebd4bf8eaf7b3a5efb3e) | `plasma-desktop: remove outdated patch`                                              |
| [`00a83105`](https://github.com/NixOS/nixpkgs/commit/00a831052345435ddc9cefd0f4cbbe99cfd83a81) | `plasma-nm: update patches`                                                          |
| [`697277d7`](https://github.com/NixOS/nixpkgs/commit/697277d7da81d43d7d56eff96969a0cfb0610ff6) | `breeze-gtk: fix build`                                                              |
| [`930b7f8e`](https://github.com/NixOS/nixpkgs/commit/930b7f8e67753c3862b722619d51551ce2e9d356) | `libksysguard: add missing dependencies`                                             |
| [`0dade18f`](https://github.com/NixOS/nixpkgs/commit/0dade18f6bf1db2df4ce3ffb7b2ce40f1270f6af) | `libksysguard: update patch`                                                         |
| [`a8e5e90b`](https://github.com/NixOS/nixpkgs/commit/a8e5e90b1a5d2acc5ec6b9fbc2ada3a470dde263) | `libkscreen: add missing dependencies`                                               |
| [`1b1dcd94`](https://github.com/NixOS/nixpkgs/commit/1b1dcd94e57bc6d246fb447aa947f2cbfa2407e1) | `kwin: remove outdated patches`                                                      |
| [`a87f5dcb`](https://github.com/NixOS/nixpkgs/commit/a87f5dcbcd8a18bfe64eaf05a60fab141a009af8) | `plasma5: 5.22.5 -> 5.22.90`                                                         |
| [`3cca04ad`](https://github.com/NixOS/nixpkgs/commit/3cca04ad9183386d5e6e5fdfa034bd4205b0aeb4) | `plasma-wayland-protocols: 1.3.0 -> 1.4.0`                                           |
| [`e9ce2737`](https://github.com/NixOS/nixpkgs/commit/e9ce273757042dd4a4d51c962d9e08a88b4fa7b7) | `kpackage: update patch`                                                             |
| [`366a6abc`](https://github.com/NixOS/nixpkgs/commit/366a6abc6d43e9b7916e7958e4e3d99e6ec79fb8) | `kio: remove outdated patch`                                                         |
| [`c4bd9241`](https://github.com/NixOS/nixpkgs/commit/c4bd924189b061199c578340d6a3f7ee22c661d6) | `kde-frameworks: 5.85 -> 5.86`                                                       |
| [`995cc4b6`](https://github.com/NixOS/nixpkgs/commit/995cc4b6a399b85b6802ff00cef99b80b3fac4da) | `kak-lsp: 11.0.0 -> 11.0.1`                                                          |
| [`5c944230`](https://github.com/NixOS/nixpkgs/commit/5c94423069c897849df478ca93de1a3886930b74) | `purple-discord: 2018-04-10 -> 2021-10-17`                                           |
| [`7fac5898`](https://github.com/NixOS/nixpkgs/commit/7fac5898af6aa1485c09a7f61b73cf23e7049866) | `signal-desktop: preload sqlcipher library from nixpkgs`                             |
| [`288cc200`](https://github.com/NixOS/nixpkgs/commit/288cc2007b1c3d60163176a1706024b9ee152393) | `lib/systems: update powernv kernel config`                                          |