### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc1535cfb9cb82c5ddd9edec76c81028195b9b6c",
-        "sha256": "1al2rqh564zfalf7mw75p80il4ps57qvism9ihjid2v6m1zl53wb",
+        "rev": "47b36ad103aeff17f9be6fb7b4847d63d53f227a",
+        "sha256": "109shladi2pj27mmna2g53m59m110pbczhnskrn3knbgpdmd78xz",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fc1535cfb9cb82c5ddd9edec76c81028195b9b6c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/47b36ad103aeff17f9be6fb7b4847d63d53f227a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`8dae7bc0`](https://github.com/NixOS/nixpkgs/commit/8dae7bc0f54b8f2ef7fde4727f190d137c94ad0b) | `chromium: 95.0.4638.54 -> 95.0.4638.69`                                        |
| [`cb5186fe`](https://github.com/NixOS/nixpkgs/commit/cb5186feead357d556ecdadb05e8ad5bc06b4442) | `signald: add module`                                                           |
| [`f97a6f81`](https://github.com/NixOS/nixpkgs/commit/f97a6f81d1b9d098dfbbe73c6553e4c7a2866532) | `signald: 0.13.1 -> 0.14.1`                                                     |
| [`00f7e1e8`](https://github.com/NixOS/nixpkgs/commit/00f7e1e88a995ef7dc83c80b531ea1b4eba2b621) | `gocryptfs: 2.1 -> 2.2.1`                                                       |
| [`c5c34f6b`](https://github.com/NixOS/nixpkgs/commit/c5c34f6be1162177555ef88165b65d7b1ea2f752) | `coqPackages.mathcomp: 1.12.0 -> 1.13.0`                                        |
| [`7e3ba3e8`](https://github.com/NixOS/nixpkgs/commit/7e3ba3e88b02c8b780075f87a3c6282eace0878e) | `backport-action: 0.0.6 -> 0.0.7`                                               |
| [`ae3fc8b8`](https://github.com/NixOS/nixpkgs/commit/ae3fc8b8d3faabb83ca7ff201096d6f806e18df4) | `pythonPackages.striprtf: init at 0.0.15`                                       |
| [`0757207f`](https://github.com/NixOS/nixpkgs/commit/0757207f330252d2882934d0ecb0fb65a399eafd) | `pythonPackages.flashtext: init at 2.7`                                         |
| [`7b77cca2`](https://github.com/NixOS/nixpkgs/commit/7b77cca268d1c0de2c22c13baf19654a47abe562) | `python38Packages.pyramid_multiauth: 0.9.0 -> 1.0.1`                            |
| [`3fc245b3`](https://github.com/NixOS/nixpkgs/commit/3fc245b3f71f6ededc0080fe2de2071fea280bce) | `python3Packages.mwdblib: 3.4.0 -> 3.4.1`                                       |
| [`7565e8eb`](https://github.com/NixOS/nixpkgs/commit/7565e8eb3278125807f7f7abafcd3232f77746d9) | `python38Packages.murmurhash: 1.0.5 -> 1.0.6`                                   |
| [`4f8999da`](https://github.com/NixOS/nixpkgs/commit/4f8999daba5dd5f56783d06f9478cde224e7637a) | `Update pkgs/tools/admin/google-cloud-sdk/default.nix`                          |
| [`b9cb71c4`](https://github.com/NixOS/nixpkgs/commit/b9cb71c48ba8b99c66040de1f9c961d6ada829ec) | `Update pkgs/tools/admin/google-cloud-sdk/default.nix`                          |
| [`bc193f80`](https://github.com/NixOS/nixpkgs/commit/bc193f80c437d2db9b7f2348dfae1e05ea756412) | `buildDotnetModule: create nuget source seperately && use stdenvNoCC`           |
| [`46bbbbb1`](https://github.com/NixOS/nixpkgs/commit/46bbbbb1e8a11606e9e8706139ead3218b47830e) | `brook: enable on darwin`                                                       |
| [`f84cf9b4`](https://github.com/NixOS/nixpkgs/commit/f84cf9b4add986190650676930bc02d20493f5d1) | `ssldump: enable on darwin`                                                     |
| [`c8f8adc5`](https://github.com/NixOS/nixpkgs/commit/c8f8adc5ec85a444618da8280d666af760925b24) | `openocd: libgpiod is supported only on linux (#143652)`                        |
| [`b96ab960`](https://github.com/NixOS/nixpkgs/commit/b96ab960d3a2ef371355f149327975799d41ed67) | `vtun: remove`                                                                  |
| [`ef150974`](https://github.com/NixOS/nixpkgs/commit/ef15097475551485dda6c070591b293bf3f71c4b) | `heisenbridge: 1.3.0 -> 1.4.0`                                                  |
| [`f151bae7`](https://github.com/NixOS/nixpkgs/commit/f151bae7ab9bfdf6f125a2a03aad0ba6bf0589dc) | `postgresql11Packages.repmgr: 5.2.1 -> 5.3.0 (#143507)`                         |
| [`01d7e711`](https://github.com/NixOS/nixpkgs/commit/01d7e7114569a6d50070e400ff648beecbc89375) | `buildkite-agent: 3.32.3 -> 3.33.3 (#143559)`                                   |
| [`c6766153`](https://github.com/NixOS/nixpkgs/commit/c6766153e3b852300d57a16fe79942485a8506bf) | `rusty-man: 0.4.3 -> 0.5.0`                                                     |
| [`fb37aecd`](https://github.com/NixOS/nixpkgs/commit/fb37aecd66d48f1e56cf7f0681586f86379b67c9) | `pylint-exit: init at 1.2.0`                                                    |
| [`b4178262`](https://github.com/NixOS/nixpkgs/commit/b417826250bd0357271ec8466084e578edb576fa) | `linuxPackages.rtw89: unstable-2021-07-03 -> unstable-2021-10-21`               |
| [`17ca0b4d`](https://github.com/NixOS/nixpkgs/commit/17ca0b4d1dbb5ca2b472ad1e8fd4fa300e2daec3) | `dyff: fix version output, install shell completions`                           |
| [`8182f670`](https://github.com/NixOS/nixpkgs/commit/8182f670c5a1f95f5de8dd5e84b751ab56b3ec20) | `dnsproxy: fix version output, fix license`                                     |
| [`c4454057`](https://github.com/NixOS/nixpkgs/commit/c44540576385fb04fa3ad89f822d79ca53e74465) | `exoscale-cli: 1.44.0 -> 1.45.2`                                                |
| [`58599aac`](https://github.com/NixOS/nixpkgs/commit/58599aac3f4e5e29bad0db2d4e96a31f8b20715d) | `tidy-viewer: 0.0.22 -> 1.4.2`                                                  |
| [`e06991e7`](https://github.com/NixOS/nixpkgs/commit/e06991e7bb5251330e40ae00ef3f004ca7ab8d7c) | `gitlab: 14.4.0 -> 14.4.1`                                                      |
| [`5d21df98`](https://github.com/NixOS/nixpkgs/commit/5d21df984af8424cc09ccc2940cb0a25aee0a3ce) | `esbuild: 0.13.0 -> 0.13.10`                                                    |
| [`b9170bf9`](https://github.com/NixOS/nixpkgs/commit/b9170bf9e0e4d4791ab7fcfb610cc88a90869590) | `epson-escpr2: 1.1.38 -> 1.1.42`                                                |
| [`7bb16975`](https://github.com/NixOS/nixpkgs/commit/7bb16975886080b84736a13bd46f0da9546a4ae2) | `khronos: 3.6.0 -> 3.6.1`                                                       |
| [`e925fd6f`](https://github.com/NixOS/nixpkgs/commit/e925fd6f70fc0fcba11c264c9d064a0dd7962fce) | `dyff: 1.4.3 -> 1.4.5`                                                          |
| [`447e3995`](https://github.com/NixOS/nixpkgs/commit/447e399559919e939787a9f83802efb33d222718) | `dua: 2.14.7 -> 2.14.11`                                                        |
| [`6efb714e`](https://github.com/NixOS/nixpkgs/commit/6efb714ef8bc483c7afdff2f4263dfc08b4b816e) | `topgrade: 8.0.0 -> 8.0.3`                                                      |
| [`a0e24f77`](https://github.com/NixOS/nixpkgs/commit/a0e24f77659cfc89369b1da58b5e95a905e7667c) | `dnsproxy: 0.39.7 -> 0.39.9`                                                    |
| [`7aa3bc1b`](https://github.com/NixOS/nixpkgs/commit/7aa3bc1b7faf920df1b35d9184fb4ae014aff81e) | `ddosify: 0.4.1 -> 0.5.1`                                                       |
| [`e997e62b`](https://github.com/NixOS/nixpkgs/commit/e997e62b0039c22f0a3886e70622050eb2340407) | `sonobuoy: 0.53.2 -> 0.54.0`                                                    |
| [`a7379ab7`](https://github.com/NixOS/nixpkgs/commit/a7379ab712c75962d389921f5087d14b8cb1104a) | `credhub-cli: 2.9.0 -> 2.9.1`                                                   |
| [`78623b7b`](https://github.com/NixOS/nixpkgs/commit/78623b7bb55813eec7b689fe2bf01a69c5657500) | `cpp-utilities: 5.11.1 -> 5.11.2`                                               |
| [`b40d30f9`](https://github.com/NixOS/nixpkgs/commit/b40d30f92d0f887c62e8baea678b059b6732a50a) | `bats: 1.4.1 -> 1.5.0`                                                          |
| [`468e539b`](https://github.com/NixOS/nixpkgs/commit/468e539bad3da0b9b1550d0156b15a401d2acac0) | `cloud-nuke: 0.5.0 -> 0.5.1`                                                    |
| [`81a43e13`](https://github.com/NixOS/nixpkgs/commit/81a43e138f57ee8d0317d57ef9efa42767dd486d) | `circleci-cli: 0.1.15848 -> 0.1.16122`                                          |
| [`850930b1`](https://github.com/NixOS/nixpkgs/commit/850930b13f409c2e7ae8b08108abbb6b40e18f06) | `arrow-cpp: search for Thrift using pkg-config instead of cmake`                |
| [`e1e38c98`](https://github.com/NixOS/nixpkgs/commit/e1e38c984eca5e915d5f1161c9b62a1f1371db89) | `cargo-msrv: 0.10.0 -> 0.11.1`                                                  |
| [`4a6ab379`](https://github.com/NixOS/nixpkgs/commit/4a6ab3798d7a9972afdb8bd70506019201edfd21) | `cfitsio: 3.49 -> 4.0.0`                                                        |
| [`fc6ccc25`](https://github.com/NixOS/nixpkgs/commit/fc6ccc25ccc31315be234e53ec6aa385107d61d7) | `treewide: fix /bin/coursier references`                                        |
| [`dd4f21bf`](https://github.com/NixOS/nixpkgs/commit/dd4f21bf84b9cef048bf6fd5bfc0ec82e3bd460b) | `signal-desktop: 5.21.0 -> 5.22.0`                                              |
| [`b497744a`](https://github.com/NixOS/nixpkgs/commit/b497744a24244ade64dbfe2b7b7132ce8837e53a) | `chromiumDev: 97.0.4676.0 -> 97.0.4682.3`                                       |
| [`362f6990`](https://github.com/NixOS/nixpkgs/commit/362f6990a6205360ea265b5e6ead3c02bbfac03d) | `chromiumBeta: 96.0.4664.18 -> 96.0.4664.27`                                    |
| [`bad7beba`](https://github.com/NixOS/nixpkgs/commit/bad7bebae4633262b9bf2feea245c7d481cb294c) | `python3Packages.gprof2dot: 201.11.30 -> 2021.02.21`                            |
| [`07ea60c4`](https://github.com/NixOS/nixpkgs/commit/07ea60c42397b170b342343f9183fb6a12c07117) | `dovecot_pigeonhole: 0.5.16 -> 0.5.17`                                          |
| [`bf6912e4`](https://github.com/NixOS/nixpkgs/commit/bf6912e49e2da2c934e7692b8f802373cc08cd0b) | `dovecot: 2.3.16 -> 2.3.17`                                                     |
| [`85e55011`](https://github.com/NixOS/nixpkgs/commit/85e55011028b9b4fe914456c8dec8278308040ac) | `molotov: remove name`                                                          |
| [`db44b28a`](https://github.com/NixOS/nixpkgs/commit/db44b28a061fa44654dda12a9d862d4fdeecefa0) | `appimage: support pname+version for wrapType2`                                 |
| [`88cff9d7`](https://github.com/NixOS/nixpkgs/commit/88cff9d704469d6d42396141d1a78a01ec5d7c5f) | `google-cloud-sdk: move nixos test to installCheck`                             |
| [`d86e178f`](https://github.com/NixOS/nixpkgs/commit/d86e178f91e4162785806193451d294e989a4f44) | `libreoffice-fresh: 7.1.5.2 -> 7.2.2.2 & libreoffice-still: 7.0.6.2 -> 7.1.6.2` |
| [`c6791b73`](https://github.com/NixOS/nixpkgs/commit/c6791b730ba50a0838e6b9c9dc585c324ca1d14d) | `intel-compute-runtime: 20.34.17727 -> 21.42.21270`                             |
| [`0eb2ab9f`](https://github.com/NixOS/nixpkgs/commit/0eb2ab9fc73046a98f875d046edd0a3c866292f9) | `intel-graphics-compiler: 1.0.4241 -> 1.0.8744`                                 |
| [`58482b71`](https://github.com/NixOS/nixpkgs/commit/58482b71b21f93e446604cbbcdd8b00d73b5b6b8) | `opencl-clang: 2019-08-16 -> 2021-06-22`                                        |
| [`30f38736`](https://github.com/NixOS/nixpkgs/commit/30f3873639265a0641ad9d0032cfa426d1588038) | `kodiPackages.youtube: 6.8.17+matrix.1 -> 6.8.18+matrix.1`                      |
| [`6554f1bd`](https://github.com/NixOS/nixpkgs/commit/6554f1bd60571cbd4de3cb69c866babb3d41038f) | `spirv-llvm-translator: 8.0.1-2 -> 2021-06-13`                                  |
| [`c5c02ea3`](https://github.com/NixOS/nixpkgs/commit/c5c02ea3203b3eafcb73c63c6464bc95fbc7a89a) | `dotty: 3.0.0 → 3.1.0`                                                          |