### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47b36ad103aeff17f9be6fb7b4847d63d53f227a",
-        "sha256": "109shladi2pj27mmna2g53m59m110pbczhnskrn3knbgpdmd78xz",
+        "rev": "e49cd51ebcbb916e2481555aad8d9548807e9d12",
+        "sha256": "1v5il2yx2020i31awad4bfw4s8r2l284wm04zgc4nf1wwj5fn76r",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/47b36ad103aeff17f9be6fb7b4847d63d53f227a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e49cd51ebcbb916e2481555aad8d9548807e9d12.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                 |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`808e44a9`](https://github.com/NixOS/nixpkgs/commit/808e44a9fddaa8066538830cd334f7874ef3eb92) | `python3Packages.cirq: add other cirq subpackages`             |
| [`3378a3e5`](https://github.com/NixOS/nixpkgs/commit/3378a3e58ceeb575a006caf1350291d4f743f74b) | `python3Packages.cirq-rigetti: unpin qcs-api-client`           |
| [`e6055980`](https://github.com/NixOS/nixpkgs/commit/e6055980a66eb3604bcf90c23876cdc69837874d) | `python3Packages.cirq-core: 0.12.0 -> 0.13.1`                  |
| [`47a40b03`](https://github.com/NixOS/nixpkgs/commit/47a40b03205e30e1647222de56644eb23e6b422c) | `python3Packages.pyquil: 3.0.0 -> 3.0.1`                       |
| [`711f6afd`](https://github.com/NixOS/nixpkgs/commit/711f6afd1e62cfcc20f567c8d404df82b7931567) | `python3Packages.duet: init at 0.2.1`                          |
| [`9efe4d4e`](https://github.com/NixOS/nixpkgs/commit/9efe4d4ed69f12290641304168b2652da8a2f9b3) | `xml2rfc: 3.10.0 -> 3.11.1`                                    |
| [`d6f5789f`](https://github.com/NixOS/nixpkgs/commit/d6f5789f3af64cb0616b50a69df59fc9fe2332d5) | `python38Packages.trimesh: 3.9.34 -> 3.9.35`                   |
| [`de68441e`](https://github.com/NixOS/nixpkgs/commit/de68441eb01ea392b255cfcde88b9adc26c7205d) | `python38Packages.mypy-boto3-s3: 1.19.4 -> 1.19.7`             |
| [`ec9cdf7b`](https://github.com/NixOS/nixpkgs/commit/ec9cdf7b306d0ab75e407004005119eb90a538d8) | `python38Packages.spacy-transformers: 1.1.1 -> 1.1.2`          |
| [`ad7cdcd2`](https://github.com/NixOS/nixpkgs/commit/ad7cdcd214cd7eaf71c025aeb336cf7ac434f87b) | `zerotierone: 1.6.6 -> 1.8.1`                                  |
| [`2ec0c698`](https://github.com/NixOS/nixpkgs/commit/2ec0c698eaf3e7a4d13988538f08d65b3d006f40) | `kodi: 19.2 -> 19.3`                                           |
| [`8f8d0b7e`](https://github.com/NixOS/nixpkgs/commit/8f8d0b7ec82db9d28637cf689da7e07969e9272d) | `python38Packages.pynetbox: 6.1.3 -> 6.2.0`                    |
| [`bc887c30`](https://github.com/NixOS/nixpkgs/commit/bc887c308bf1cdc3337baf2ce1357e452078ac28) | `rqbit: 2.1.0 -> 2.1.2`                                        |
| [`29a10a5e`](https://github.com/NixOS/nixpkgs/commit/29a10a5e07044b262e3927f223fc60cfcfb8029d) | `ytcc: add marsam to maintainers`                              |
| [`1840a292`](https://github.com/NixOS/nixpkgs/commit/1840a292ecd289802f226c0d6dc5337b38e36800) | `ytcc: use yt-dlp`                                             |
| [`1839c17e`](https://github.com/NixOS/nixpkgs/commit/1839c17eb5c25907c156375d2aec7ea21c47242d) | `ytcc: install manpage`                                        |
| [`4dde1d26`](https://github.com/NixOS/nixpkgs/commit/4dde1d266c1d3eb956a7e6df764fd90b0cd70e6a) | `gfbgraph: 0.2.4 → 0.2.5`                                      |
| [`ffee0fc3`](https://github.com/NixOS/nixpkgs/commit/ffee0fc3ca860be96f9a45b45ca81db08339e827) | `flat-remix-gnome: 20210921 -> 20211028`                       |
| [`b58eda9b`](https://github.com/NixOS/nixpkgs/commit/b58eda9b91d99ac880355495e1476a696bbbc317) | `ytcc: 2.5.1 -> 2.5.2`                                         |
| [`67d9fb1a`](https://github.com/NixOS/nixpkgs/commit/67d9fb1a268cb843236e32fdac5b079ebee71ef2) | `babashka: 0.6.2 -> 0.6.4`                                     |
| [`a8f9539d`](https://github.com/NixOS/nixpkgs/commit/a8f9539d0171a5ae9285692805c0b206cfee9fde) | `lemmy: systemd postgresql setup service cleanup`              |
| [`f2f1af92`](https://github.com/NixOS/nixpkgs/commit/f2f1af9201d13c198f0fbfd68e1748e40efc0146) | `hyprspace: 0.1.6 -> 0.1.7`                                    |
| [`ecebf060`](https://github.com/NixOS/nixpkgs/commit/ecebf0602cb068c784f386dd7f0bbeba57d619e4) | `svtplay-dl: 4.7 -> 4.8`                                       |
| [`54b46812`](https://github.com/NixOS/nixpkgs/commit/54b46812250dfcca4366ad49cb5566e0ddcc37ab) | `hcloud: 1.28.0 -> 1.28.1`                                     |
| [`860efc6d`](https://github.com/NixOS/nixpkgs/commit/860efc6d8a298849705d733eb016a5020868375a) | `gxkb: 0.9.2 -> 0.9.3`                                         |
| [`e992d588`](https://github.com/NixOS/nixpkgs/commit/e992d58863146b9f3b36d4d7cd867fb0eedb14c4) | `grpcui: 1.1.0 -> 1.2.0`                                       |
| [`16c44bdd`](https://github.com/NixOS/nixpkgs/commit/16c44bdd0a878909ba6303ddbac2719720d187c4) | `grafana-agent: 0.18.4 -> 0.20.0`                              |
| [`d71409c0`](https://github.com/NixOS/nixpkgs/commit/d71409c0de694ecbefa05d78a53adefcbb46a72b) | `ungoogled-chromium: 95.0.4638.54 -> 95.0.4638.69`             |
| [`aaf0da74`](https://github.com/NixOS/nixpkgs/commit/aaf0da74e8c506a589506c22e4f3c9b8f14396f7) | `goreleaser: 0.179.0 -> 0.183.0`                               |
| [`e6849090`](https://github.com/NixOS/nixpkgs/commit/e68490906825f45f338eaaebdd014fda107da9df) | `gobgpd: 2.31.0 -> 2.32.0`                                     |
| [`2aa4abea`](https://github.com/NixOS/nixpkgs/commit/2aa4abea95902a89c4b0eb05e2e665afd3703680) | `gobgp: 2.31.0 -> 2.32.0`                                      |
| [`3e9e6c33`](https://github.com/NixOS/nixpkgs/commit/3e9e6c33681afbdd52b9db0ca50d8be6d7f90520) | `go-minimock: 3.0.9 -> 3.0.10`                                 |
| [`1bba1465`](https://github.com/NixOS/nixpkgs/commit/1bba146541b31eb4d63b9956ba480ba07dafb8e8) | `gerbera: 1.9.1 -> 1.9.2`                                      |
| [`8cab2c14`](https://github.com/NixOS/nixpkgs/commit/8cab2c1472806b3036e747650e85c926e9393264) | `gdcm: 3.0.9 -> 3.0.10`                                        |
| [`f7f718aa`](https://github.com/NixOS/nixpkgs/commit/f7f718aaf82180506e21191c3b645c76eb1b564c) | `folly: 2021.09.20.00 -> 2021.10.25.00`                        |
| [`09ea79b8`](https://github.com/NixOS/nixpkgs/commit/09ea79b83447ed768df79f003d6a9776c995ab84) | `fluxcd: 0.19.1 -> 0.20.0`                                     |
| [`7673120a`](https://github.com/NixOS/nixpkgs/commit/7673120a1ebc4bb75392eb59e9c0bd92f600f81b) | `fluent-bit: 1.8.6 -> 1.8.9`                                   |
| [`9fe97e63`](https://github.com/NixOS/nixpkgs/commit/9fe97e63e63d8a0b3c9becb7e8b23199e9b3bd8d) | `flow: 0.160.1 -> 0.163.0`                                     |
| [`a5b1903e`](https://github.com/NixOS/nixpkgs/commit/a5b1903e541158b8ea866ba66106fcee7e29baaa) | `whitesur-icon-theme: 20210826 -> 20211013`                    |
| [`4ace6209`](https://github.com/NixOS/nixpkgs/commit/4ace62092bc3c96712e586c3a69ab2b511e4fa58) | `fits-cloudctl: 0.10.0 -> 0.10.3`                              |
| [`0def7fb8`](https://github.com/NixOS/nixpkgs/commit/0def7fb8c1e0c785134746d127aa6091d7018df1) | `featherpad: 1.0.0 -> 1.0.1`                                   |
| [`60068ca4`](https://github.com/NixOS/nixpkgs/commit/60068ca40c1243b3017400249c5803330cd4b385) | `ergo: 4.0.13 -> 4.0.15`                                       |
| [`b6aeb674`](https://github.com/NixOS/nixpkgs/commit/b6aeb674373e001b300987c948c4d1e5d0084e33) | `gnome-online-accounts: 3.40.0 → 3.40.1`                       |
| [`f930c083`](https://github.com/NixOS/nixpkgs/commit/f930c08357de9e55cfa91c5cc7a6c0f2b2d64d5b) | `gnome-connections: 41.0 → 41.1`                               |
| [`0247146b`](https://github.com/NixOS/nixpkgs/commit/0247146b01a1f9f45577cc00c120ff0b4a42fb02) | `gnome.gnome-software: 41.0 → 41.1`                            |
| [`76e31c3f`](https://github.com/NixOS/nixpkgs/commit/76e31c3fd204c5058593bcb4e63f62e633506b8d) | `gnome.gnome-control-center: 41.0 → 41.1`                      |
| [`1765d5e3`](https://github.com/NixOS/nixpkgs/commit/1765d5e3ad5fd21a8042c979ca010c8dd8627bf4) | `evolution: 3.42.0 → 3.42.1`                                   |
| [`2d4f057c`](https://github.com/NixOS/nixpkgs/commit/2d4f057ca647a9f60786ba85edb134960c8b3c3a) | `evolution-data-server: 3.42.0 → 3.42.1`                       |
| [`9d43a43d`](https://github.com/NixOS/nixpkgs/commit/9d43a43d1d8c15013861530897bd0db151074a1e) | `evolution-ews: 3.42.0 → 3.42.1`                               |
| [`0ee1aa2d`](https://github.com/NixOS/nixpkgs/commit/0ee1aa2d606d8bfa7d4914a5e7e0901fb54497c8) | `consul-template: 0.27.0 -> 0.27.1`                            |
| [`fcfa8725`](https://github.com/NixOS/nixpkgs/commit/fcfa87253def59a6cda3aab389663486e85a0570) | `sagittarius-scheme: 0.9.7 -> 0.9.8`                           |
| [`398b56f7`](https://github.com/NixOS/nixpkgs/commit/398b56f74cb252606f4ff9aba5b4541e65f5a943) | `rocksdb: 6.23.3 -> 6.25.3`                                    |
| [`8aa05c73`](https://github.com/NixOS/nixpkgs/commit/8aa05c73c131bff9b6b243f09c1fc36130f84a80) | `rbenv: 1.1.2 -> 1.2.0`                                        |
| [`4eb923fc`](https://github.com/NixOS/nixpkgs/commit/4eb923fc9946123794aefa6e239d5a47bf3ec957) | `argocd: 2.1.2 -> 2.1.5`                                       |
| [`5fc771ba`](https://github.com/NixOS/nixpkgs/commit/5fc771ba1f37ac979e8bdb6332f49ade9f0bc0d8) | `wsjtx: 2.4.0 -> 2.5.1`                                        |
| [`6767e0ed`](https://github.com/NixOS/nixpkgs/commit/6767e0ed8e79bcbe408cabfcb327295d90597cc2) | `gnome.nautilus-python: fix loading gi`                        |
| [`5d5a5fce`](https://github.com/NixOS/nixpkgs/commit/5d5a5fce909a3251312192c49d99837fa809ac29) | `nixos/plantuml-server: use graphviz instead of graphviz_2_32` |
| [`536d1142`](https://github.com/NixOS/nixpkgs/commit/536d114230077a231e2e537e3301be02257b5214) | `plantuml-server: 1.2021.7 -> 1.2021.12`                       |
| [`e7898e12`](https://github.com/NixOS/nixpkgs/commit/e7898e1226ecf1107f7268674bc3f68af0f3f689) | `Add command to switch to root`                                |