### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e49cd51ebcbb916e2481555aad8d9548807e9d12",
-        "sha256": "1v5il2yx2020i31awad4bfw4s8r2l284wm04zgc4nf1wwj5fn76r",
+        "rev": "4fe24a325d842bdfe8203d714ee83c1c2c81db62",
+        "sha256": "1zvj1nhwxf8yi8m5yl48gg82krij0gy27hnfi7bhgci792wp5b6x",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e49cd51ebcbb916e2481555aad8d9548807e9d12.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/4fe24a325d842bdfe8203d714ee83c1c2c81db62.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                  |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`4fe24a32`](https://github.com/NixOS/nixpkgs/commit/4fe24a325d842bdfe8203d714ee83c1c2c81db62) | `hunter: remove`                                                |
| [`530281c3`](https://github.com/NixOS/nixpkgs/commit/530281c3c1bdf3d748689d70f0283200cc0dc889) | `ocamlPackages.awa: 0.0.3 -> 0.0.4`                             |
| [`fc21a609`](https://github.com/NixOS/nixpkgs/commit/fc21a60920e86405ad9cfcc925e7cf78f3b585a2) | `python3Packages.herepy: 3.5.5 -> 3.5.6`                        |
| [`e46dfcbd`](https://github.com/NixOS/nixpkgs/commit/e46dfcbde38ea1b4c7d9b7ac11a16912c308f548) | `python38Packages.msal: 1.15.0 -> 1.16.0`                       |
| [`49d91d32`](https://github.com/NixOS/nixpkgs/commit/49d91d32c8a9fab2602d1ba6241fda033ad006c3) | `python3Packages.dulwich: 0.20.25 -> 0.20.26`                   |
| [`da995f89`](https://github.com/NixOS/nixpkgs/commit/da995f89909622b95f041ed1d18494250f6e4ee2) | `python38Packages.casbin: 1.9.3 -> 1.9.4`                       |
| [`a7a375b3`](https://github.com/NixOS/nixpkgs/commit/a7a375b3d41c7018c53d3974e968d939b7661835) | `libsForQt5.qtutilities: Update description`                    |
| [`aac43ad4`](https://github.com/NixOS/nixpkgs/commit/aac43ad47d8c6144b2a8ea88829627c2077e4bf4) | `pythonPackages.pycangjie: switch to fetchFromGitHub`           |
| [`aa57bfb3`](https://github.com/NixOS/nixpkgs/commit/aa57bfb3ea84062fe156af6661429c8dc02439d1) | `pythonPackages.pyside: switch to fetchFromGitHub`              |
| [`9001546f`](https://github.com/NixOS/nixpkgs/commit/9001546fab28fdd3a09fec6d30b2d88234601068) | `pythonPackages.pyspotify: switch to fetchFromGitHub`           |
| [`697b1c11`](https://github.com/NixOS/nixpkgs/commit/697b1c1105d867d4ef56c55dcc45259d9e7f67df) | `pythonPackages.sfepy: switch to fetchFromGitHub`               |
| [`29c09dcf`](https://github.com/NixOS/nixpkgs/commit/29c09dcfa5399522c5d287f23f39da0293f2dce7) | `pythonPackages.upass: switch to fetchFromGitHub`               |
| [`f0843b3c`](https://github.com/NixOS/nixpkgs/commit/f0843b3c64e75c20bea8314967ac46294bfac0c5) | `pythonPackages.usbtmc: switch to fetchFromGitHub`              |
| [`18664585`](https://github.com/NixOS/nixpkgs/commit/18664585ac86892c2840b688be31c0b708fe0839) | `rebar: switch to fetchFromGitHub`                              |
| [`3e572042`](https://github.com/NixOS/nixpkgs/commit/3e5720426b86d6360572b53a97f216bdd82fec32) | `haskellPackages.vaultenv: switch to fetchFromGitHub`           |
| [`c1b85df6`](https://github.com/NixOS/nixpkgs/commit/c1b85df6ad6ccd49c87d1c26bc63bb95eaeed929) | `obuild: switch to fetchFromGitHub`                             |
| [`1dcfdaf9`](https://github.com/NixOS/nixpkgs/commit/1dcfdaf9eb80819eb98bafe39b3e5145c63f1c63) | `ocaml-top: switch to fetchFromGitHub`                          |
| [`bcf11847`](https://github.com/NixOS/nixpkgs/commit/bcf11847a29e79336c0dcda350135817ed850828) | `ocamlPackages.ocp-indent: switch to fetchFromGitHub`           |
| [`8f1a669d`](https://github.com/NixOS/nixpkgs/commit/8f1a669d9f3c7740d641ba9ee40947b4cfc9998b) | `ocsigen-i18n: switch to fetchFromGitHub`                       |
| [`f7c07825`](https://github.com/NixOS/nixpkgs/commit/f7c07825b922939501b62d5ab3049228188e740e) | `udis86: cleanup`                                               |
| [`aac38fed`](https://github.com/NixOS/nixpkgs/commit/aac38fedf512eb6f1c263d479fa26ced4a5fedd6) | `remarkjs: switch to fetchFromGitHub`                           |
| [`676bbe42`](https://github.com/NixOS/nixpkgs/commit/676bbe428ba77e9815a5e7741af01017a8aec9ff) | `python3Packages.certbot-dns-*: lint`                           |
| [`b273bce1`](https://github.com/NixOS/nixpkgs/commit/b273bce17a6ffd162cfb943615ea43c21ac5cae5) | `python3Packages.certbot-dns-google: init at 1.20.0`            |
| [`5acdca8b`](https://github.com/NixOS/nixpkgs/commit/5acdca8bebeed84cf74ff23f7b9ee3d3bb86caf5) | `delta: 0.9.1 -> 0.9.2`                                         |
| [`17f73e22`](https://github.com/NixOS/nixpkgs/commit/17f73e226198a511a74a953758ceed6efdad9444) | `python3Packages.mitogen: 0.3.0rc1 -> 0.3.0`                    |
| [`80f971df`](https://github.com/NixOS/nixpkgs/commit/80f971dffd715fd307185673878ca3fd3ca735ed) | `keyscope: fix darwin build`                                    |
| [`571aa747`](https://github.com/NixOS/nixpkgs/commit/571aa747d41b03c584854ee7c59c5082123a7f78) | `python38Packages.mautrix: 0.10.10 -> 0.10.11`                  |
| [`669fa079`](https://github.com/NixOS/nixpkgs/commit/669fa0790caada7527de515be1ff0ca213cde00e) | `piping-server-rust: fix darwin build`                          |
| [`3b02a12f`](https://github.com/NixOS/nixpkgs/commit/3b02a12f2ae9f73a3f6f67f12bf6968b00e68578) | `lucky-commit: fix darwin build`                                |
| [`185e6a47`](https://github.com/NixOS/nixpkgs/commit/185e6a477ad5540c110e9c631a8a93cfa40d8b8a) | `sssd: 1.16.5 -> 2.6.0, fix broken build`                       |
| [`02ac19b5`](https://github.com/NixOS/nixpkgs/commit/02ac19b524467e1de5b1efb3853a496b936f8df2) | `python3Packages.millheater: 0.7.3 -> 0.8.0`                    |
| [`5d1f9a18`](https://github.com/NixOS/nixpkgs/commit/5d1f9a18d5fbe4afd60dd0c8b266fbb81881d53e) | `ocamlPackages.sedlex: switch to fetchFromGitHub`               |
| [`a1f3382f`](https://github.com/NixOS/nixpkgs/commit/a1f3382fb62e8f801a58e4f71fcdd0a90bcdcd12) | `ocamlPackages.sqlite3EZ: switch to fetchFromGitHub`            |
| [`156e4d31`](https://github.com/NixOS/nixpkgs/commit/156e4d312d18a00bd6b8d059b769a290a58aa8fd) | `ocamlPackages.twt: switch to fetchFromGitHub`                  |
| [`8746c814`](https://github.com/NixOS/nixpkgs/commit/8746c8141f06b677edb4cccfd6fb7ad9a806c50a) | `ocamlPackages.typerep: switch to fetchFromGitHub`              |
| [`6fd5756e`](https://github.com/NixOS/nixpkgs/commit/6fd5756e496487882fa0370792f458834b2d080d) | `ocamlPackages.variantslib: switch to fetchFromGitHub`          |
| [`fb0c89af`](https://github.com/NixOS/nixpkgs/commit/fb0c89af55d39a52c8702839d21e55c2557de116) | `ocamlPackages.xml-light: switch to fetchFromGitHub`            |
| [`256c71f7`](https://github.com/NixOS/nixpkgs/commit/256c71f7fa51fa2a7d5be461fbee7d20c4dbf9d0) | `pythonPackages.audiotools: switch to fetchFromGitHub`          |
| [`971ee7fe`](https://github.com/NixOS/nixpkgs/commit/971ee7fe70bcf7d6125bfe4c5930ff94241a1fde) | `pythonPackages.etcd: switch to fetchFromGitHub`                |
| [`848e1bf2`](https://github.com/NixOS/nixpkgs/commit/848e1bf2a63fe84ddaf1a0885b62a27a8b760d3b) | `pythonPackages.gdrivefs: switch to fetchFromGitHub`            |
| [`030b88cc`](https://github.com/NixOS/nixpkgs/commit/030b88cc662e6d285bfdda010b0e2a86770117f8) | `pythonPackages.jsonwatch: switch to fetchFromGitHub`           |
| [`d2aaf040`](https://github.com/NixOS/nixpkgs/commit/d2aaf04033d29c1e71ff083eb65d5e16f4ef2c8e) | `pythonPackages.le: switch to fetchFromGitHub`                  |
| [`c4762eac`](https://github.com/NixOS/nixpkgs/commit/c4762eacc3167e5bc49d7d1442f615ea6274bef1) | `pythonPackages.livestreamer-curses: switch to fetchFromGitHub` |
| [`f3c0ece5`](https://github.com/NixOS/nixpkgs/commit/f3c0ece56c7ee0792d2678ceed0a5e96ac14336c) | `pythonPackages.livestreamer: switch to fetchFromGitHub`        |
| [`502f8e33`](https://github.com/NixOS/nixpkgs/commit/502f8e332365e7dda72a4ecfc22714edb0c9fb58) | `pythonPackages.pep257: switch to fetchFromGitHub`              |
| [`cb5ed75b`](https://github.com/NixOS/nixpkgs/commit/cb5ed75b6610ae17088e96a347a209aec587eb9f) | `python3Packages.identify: 2.3.0 -> 2.3.1`                      |
| [`8a4bee57`](https://github.com/NixOS/nixpkgs/commit/8a4bee574dbbb75eb9474e01f3b2c2f3f02811e8) | `python39Packages.elasticsearch: 7.13.1 -> 7.15.1`              |
| [`11201232`](https://github.com/NixOS/nixpkgs/commit/1120123213c5715cbf539016d7245b37443ae20f) | `clair: 4.3.0 -> 4.3.2`                                         |
| [`66b10170`](https://github.com/NixOS/nixpkgs/commit/66b1017012b6df006786df8d605a4e5346e80b24) | `checkmate: 0.4.5 -> 0.4.6`                                     |
| [`9145f833`](https://github.com/NixOS/nixpkgs/commit/9145f833cc4050876fd8d0b93a37ca5114ea381c) | `nixos/nixos-enter: bind mount /etc/resolv.conf to chroot`      |
| [`c40049dc`](https://github.com/NixOS/nixpkgs/commit/c40049dcda10ab0d5d6b71276aff1451f4b8acaf) | `cargo-deny: 0.9.1 -> 0.10.0`                                   |
| [`a2452af3`](https://github.com/NixOS/nixpkgs/commit/a2452af32266fd078a3e21a17cfa37aa6d0a1dbc) | `python38Packages.pygmt: 0.4.1 -> 0.5.0`                        |
| [`fa0bfdbe`](https://github.com/NixOS/nixpkgs/commit/fa0bfdbe0906d26ff29fdaf62cadf43700145ba7) | `nixos/invidious: add test`                                     |
| [`f1447fda`](https://github.com/NixOS/nixpkgs/commit/f1447fdaa852ea4d3685d3b7883af64789ab2a02) | `nixos/invidious: init`                                         |
| [`c5286421`](https://github.com/NixOS/nixpkgs/commit/c5286421bc3af5ca8fa8596d4761b8d8df32fccf) | `invidious: init at unstable-2021-10-15`                        |
| [`c6064b7c`](https://github.com/NixOS/nixpkgs/commit/c6064b7c4a3aa497be99feed4eb5922e1a32c86d) | `doc/crystal: Update to mention shard.lock file generation`     |
| [`5e6446ce`](https://github.com/NixOS/nixpkgs/commit/5e6446cef086c6f623dbd6b2a417fe3c7251569b) | `pantheon.elementary-shortcut-overlay: 1.2.0 -> 1.2.1`          |
| [`8890323d`](https://github.com/NixOS/nixpkgs/commit/8890323d76a672ec9dc604147ff25dca96b27adf) | `pantheon.appcenter: 3.8.1 -> 3.8.2`                            |
| [`6c43218b`](https://github.com/NixOS/nixpkgs/commit/6c43218b7de3e41fd3cd914b1ea37b5d8f84f6a4) | `pantheon.elementary-files: 6.0.3 -> 6.0.4`                     |
| [`4ff5390f`](https://github.com/NixOS/nixpkgs/commit/4ff5390f07ab7f88d275a5a5c9ba39a5d6d9c4e4) | `maintainers: correct expipiplus1 entry`                        |
| [`c2984a08`](https://github.com/NixOS/nixpkgs/commit/c2984a086f33d754e19f8adf3dfab1d1b34577ea) | `argocd: 2.1.5 -> 2.1.6`                                        |
| [`657019ab`](https://github.com/NixOS/nixpkgs/commit/657019ab27de9f257375b7a443204dbcf8883fdf) | `terragrunt: 0.35.1 -> 0.35.5`                                  |
| [`80881aa0`](https://github.com/NixOS/nixpkgs/commit/80881aa033d9172e88fbe59d1ef9b590e709e773) | `telegraf: 1.20.2 -> 1.20.3`                                    |
| [`00af64ce`](https://github.com/NixOS/nixpkgs/commit/00af64cee3a176a4380924bac3ad1c0c6950a02b) | `nsh: init at 0.4.2`                                            |
| [`baaa451a`](https://github.com/NixOS/nixpkgs/commit/baaa451a43adf927cd28ec3b9c64c25a0f8e3e17) | `python38Packages.pysma: 0.6.7 -> 0.6.8`                        |
| [`314e64e4`](https://github.com/NixOS/nixpkgs/commit/314e64e4676baa1aa15b2b043cea9bdf4d665d2d) | `coqPackages.hierarchy-builder: etc`                            |
| [`ffa5563d`](https://github.com/NixOS/nixpkgs/commit/ffa5563d2bc3bcc25f8aeb0a54bf34d001636066) | `pantheon.elementary-capnet-assist: 2.3.0 -> 2.4.0`             |
| [`cc167a57`](https://github.com/NixOS/nixpkgs/commit/cc167a573644e0888c6b4ba3473fc252c4499383) | `iamy: 2.3.2 -> 2.4.0`                                          |
| [`90f156d6`](https://github.com/NixOS/nixpkgs/commit/90f156d6e1363a0079b1fb154189014fd459ec43) | `hyper: 3.1.3 -> 3.1.4`                                         |
| [`3c86dcdb`](https://github.com/NixOS/nixpkgs/commit/3c86dcdb00e5d40a3e6f0fe326a508304de96f91) | `hurl: 1.3.1 -> 1.4.0`                                          |
| [`366e2f91`](https://github.com/NixOS/nixpkgs/commit/366e2f91a8e2e724af5f45a28584a6727c8fcfdc) | `humioctl: 0.28.6 -> 0.28.11`                                   |
| [`30f5f0a5`](https://github.com/NixOS/nixpkgs/commit/30f5f0a5afa56f32ed80fb9341a8cf32268d0913) | `helmsman: 3.7.5 -> 3.7.7`                                      |
| [`f88695d0`](https://github.com/NixOS/nixpkgs/commit/f88695d009155621e58f8c3a560102737e58e911) | `bat: move nixos test to installCheckPhase`                     |
| [`31261990`](https://github.com/NixOS/nixpkgs/commit/31261990cd596182d72dd7ee9a253d27e1b454cb) | `heimer: 2.6.0 -> 2.8.0`                                        |
| [`cd1a0619`](https://github.com/NixOS/nixpkgs/commit/cd1a0619db1c4833fb15e4311824d0d9a90f0048) | `headscale: 0.10.5 -> 0.11.0`                                   |
| [`6c00aa99`](https://github.com/NixOS/nixpkgs/commit/6c00aa991b8a59526c9b7b9120451868f1611b96) | `grype: 0.22.0 -> 0.24.0`                                       |
| [`2ff4bea9`](https://github.com/NixOS/nixpkgs/commit/2ff4bea916119a6bbef74573c894737e40f77d79) | `grpcurl: 1.8.2 -> 1.8.5`                                       |
| [`5d0d7b12`](https://github.com/NixOS/nixpkgs/commit/5d0d7b120f1e5d192cb555611650ec81f4dcb1ae) | `gqrx: 2.14.4 -> 2.14.6`                                        |
| [`be7fe7f5`](https://github.com/NixOS/nixpkgs/commit/be7fe7f5501431d20894e2f677272daf9fd5364c) | `gpg-tui: 0.8.0 -> 0.8.1`                                       |
| [`635eb3b8`](https://github.com/NixOS/nixpkgs/commit/635eb3b8edc789f2154b2e930072820ad09d222f) | `gops: 0.3.20 -> 0.3.22`                                        |
| [`ff920577`](https://github.com/NixOS/nixpkgs/commit/ff92057721a1c8359edf24ea209149bca3932285) | `google-java-format: 1.11.0 -> 1.12.0`                          |
| [`5dd00175`](https://github.com/NixOS/nixpkgs/commit/5dd001752730097799da6fa7796534c0feadbde4) | `go-task: 3.7.3 -> 3.9.0`                                       |
| [`769f38a2`](https://github.com/NixOS/nixpkgs/commit/769f38a29bd5a8020f8248461bfcf2c24b23cd31) | `go-swagger: 0.27.0 -> 0.28.0`                                  |
| [`0ee8a5ba`](https://github.com/NixOS/nixpkgs/commit/0ee8a5ba9428736f40d44c9b43a6e53b8fef6894) | `go-migrate: 4.15.0 -> 4.15.1`                                  |
| [`b3c86b43`](https://github.com/NixOS/nixpkgs/commit/b3c86b4334ae6b54dabac2a9c4ccda28f4539d1c) | `gnudatalanguage: 1.0.0 -> 1.0.1`                               |
| [`e66cf125`](https://github.com/NixOS/nixpkgs/commit/e66cf1256f4cb44bac249c332461f0cb413e5964) | `globalprotect-openconnect: 1.2.6 -> 1.3.4`                     |
| [`91b13642`](https://github.com/NixOS/nixpkgs/commit/91b13642bca7fdc801d9630338a8f38a717a0eaf) | `ginkgo: 1.16.4 -> 1.16.5`                                      |
| [`5dfd233a`](https://github.com/NixOS/nixpkgs/commit/5dfd233a64a8bd1d6f7ddbc29ca0c2d2d919e0ca) | `fselect: 0.7.6 -> 0.7.7`                                       |
| [`4bc5d055`](https://github.com/NixOS/nixpkgs/commit/4bc5d055fac947c7b4f09e8540984c63b4532b00) | `frugal: 3.14.9 -> 3.14.10`                                     |
| [`bfaa785d`](https://github.com/NixOS/nixpkgs/commit/bfaa785d8b14de25eaeebf102b4ed5df5e2c2f60) | `frp: 0.37.1 -> 0.38.0`                                         |
| [`5b12643b`](https://github.com/NixOS/nixpkgs/commit/5b12643bf35c8a0fdac95cb60d57eb65fc1f5886) | `flyctl: 0.0.241 -> 0.0.250`                                    |
| [`0615bf07`](https://github.com/NixOS/nixpkgs/commit/0615bf0751f32449b7f7060cae4371d542cd6800) | `fly: 7.5.0 -> 7.6.0`                                           |
| [`19fec730`](https://github.com/NixOS/nixpkgs/commit/19fec7306e6f6bfc447ce04cbbcfe3ac255afd2f) | `vimPlugisn.statix: add simple check and note for version`      |
| [`cf5da073`](https://github.com/NixOS/nixpkgs/commit/cf5da073954204e72539d7cc4b32fcb830c80751) | `vimPlugins.statix: init at 0.1.0`                              |
| [`072b0733`](https://github.com/NixOS/nixpkgs/commit/072b07330975ba8e147baef49719861adb669b4e) | `statix: init at 0.3.1`                                         |
| [`c014dcd5`](https://github.com/NixOS/nixpkgs/commit/c014dcd5ac1aaa7138622493f6f042c3493be104) | `flavours: 0.5.0 -> 0.5.1`                                      |
| [`cfade5b9`](https://github.com/NixOS/nixpkgs/commit/cfade5b9bbe186b8678527c32678f679f4832e79) | `firebird-emu: 1.4 -> 1.5`                                      |
| [`e6b18073`](https://github.com/NixOS/nixpkgs/commit/e6b180737a3e0d036b34daab73b038edae936b95) | `fend: 0.1.24 -> 0.1.26`                                        |
| [`f8392d5e`](https://github.com/NixOS/nixpkgs/commit/f8392d5ec775f5a83f29f6007cb0b47ffc33a168) | `elinks: 0.14.2 -> 0.14.3`                                      |
| [`0dda9a3a`](https://github.com/NixOS/nixpkgs/commit/0dda9a3a5abeb782d67ab186e436a26e338fec70) | `eksctl: 0.69.0 -> 0.70.0`                                      |
| [`8d64aee5`](https://github.com/NixOS/nixpkgs/commit/8d64aee5a36ea47fb7d5a59d2598857f6c8760f2) | `clj-kondo: 2021.09.25 -> 2021.10.19`                           |
| [`6245ade5`](https://github.com/NixOS/nixpkgs/commit/6245ade52e37634ed8b7545474b1bb9e62b8bef5) | `libsForQt5.qtutilities: 6.5.0 -> 6.5.1`                        |
| [`29de38dd`](https://github.com/NixOS/nixpkgs/commit/29de38dde9c153b9c483503039deb5ae73b295f3) | `chezmoi: 2.6.1 -> 2.7.3`                                       |
| [`10729123`](https://github.com/NixOS/nixpkgs/commit/10729123d2a07da751ce03f4316b0a508fc982c2) | `metals: add fabianhjr as maintainer`                           |
| [`d0fa01a2`](https://github.com/NixOS/nixpkgs/commit/d0fa01a2690b32c0bf37db9db4242110ac04f0bb) | `metals: 0.10.7 → 0.10.8`                                       |
| [`d2d465c9`](https://github.com/NixOS/nixpkgs/commit/d2d465c960aed111283b9b4125e4b76755f25de8) | `xgboost: 1.4.1 -> 1.5.0`                                       |
| [`e7a05e90`](https://github.com/NixOS/nixpkgs/commit/e7a05e90da04e806b3002ef5817c031fcc973b97) | `argyllcms: make reproducible`                                  |
| [`60e61073`](https://github.com/NixOS/nixpkgs/commit/60e61073917cc474bc9ed8e78e71b5b689bedafc) | `graalvm-ce: fix nix-shell incantation order on update.sh`      |
| [`81df00fb`](https://github.com/NixOS/nixpkgs/commit/81df00fb45b8140c330f4ce821c8e9a95ecd2495) | `graalvm-ce: add hashes parameter to mkGraal`                   |
| [`19e8890e`](https://github.com/NixOS/nixpkgs/commit/19e8890e5f8667f20b462287c8772bfd3328f656) | `graalvm-ce: add missing gnused to update.sh`                   |
| [`58a7dfac`](https://github.com/NixOS/nixpkgs/commit/58a7dfacb8b94c47d441273653939c8f576e2013) | `graalvm-ce: add graalvm17-ce`                                  |
| [`eb16b065`](https://github.com/NixOS/nixpkgs/commit/eb16b065f8abaaa6277533a7c010861bd1a62829) | `graalvm-ce: remove nativePRNGWorkaround`                       |
| [`cffe19bd`](https://github.com/NixOS/nixpkgs/commit/cffe19bdbe4083b855dc7f67403433ee99d11607) | `graalvm-ce: remove version file, use nix itself`               |
| [`cd3e6a49`](https://github.com/NixOS/nixpkgs/commit/cd3e6a497b1963a91195414dd3c3360e7b15387b) | `jwm-settings-manager: 2018-10-19 -> 2019-01-27`                |
| [`290b16bf`](https://github.com/NixOS/nixpkgs/commit/290b16bfe525fd80b7ad83c2027f1a26e64cb76e) | `coqPackages.zorns-lemma: fix build of versions pre-9.0`        |